### PR TITLE
Use Gravatar for profile pictures by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :assets do
 end
 
 gem "devise"
+gem "gravatar-ultimate"
 gem "haml-rails"
 gem "i18n_routing"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       multipart-post (~> 1.1)
       rack (~> 1.1)
     ffi (1.0.11)
+    gravatar-ultimate (1.0.3)
     haml (3.1.4)
     haml-rails (0.3.4)
       actionpack (~> 3.0)
@@ -212,6 +213,7 @@ DEPENDENCIES
   database_cleaner
   devise
   factory_girl_rails (= 1.4.0)
+  gravatar-ultimate
   haml-rails
   i18n_routing
   jquery-rails

--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -23,6 +23,10 @@ class Citizen < ActiveRecord::Base
     :image
   ].each { |attribute| delegate attribute, to: :profile }
 
+  def image
+    profile.image || Gravatar.new(email).image_url
+  end
+
   def self.find_for_facebook_auth(auth_hash)
     auth = Authentication.where(provider: auth_hash[:provider], uid: auth_hash[:uid]).first
     auth && auth.citizen || nil

--- a/spec/models/citizen_spec.rb
+++ b/spec/models/citizen_spec.rb
@@ -1,5 +1,26 @@
 require 'spec_helper'
 
 describe Citizen do
+  describe "with profile picture" do
+    before do
+      profile = Factory(:profile, :image => "http://www.facebook.com/images/1234.png")
+      @citizen = Factory(:citizen, :profile => profile)
+    end
+
+    it "should use user specified profile picture" do
+      @citizen.image.should == "http://www.facebook.com/images/1234.png"
+    end
+  end
+
+  describe "without profile picture" do
+    before do
+      @citizen = Factory(:citizen, :email => "foo@example.com")
+    end
+
+    it "should use gravatar by default" do
+      @citizen.image.should == "http://www.gravatar.com/avatar/b48def645758b95537d4424c84d1a9ff"
+    end
+  end
+
   it { should have_one :profile }
 end


### PR DESCRIPTION
This patch makes Citizen#image fallback to Gravatar URL if profile image is not
specified. This is useful for people who sign up without using their Facebook
account.

Signed-off-by: Pekka Enberg penberg@kernel.org
