### PR TITLE
User friendly URLs for ideas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :assets do
 end
 
 gem "devise"
+gem "friendly_id"
 gem "gravatar-ultimate"
 gem "haml-rails"
 gem "i18n_routing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       multipart-post (~> 1.1)
       rack (~> 1.1)
     ffi (1.0.11)
+    friendly_id (4.0.1)
     gravatar-ultimate (1.0.3)
     haml (3.1.4)
     haml-rails (0.3.4)
@@ -213,6 +214,7 @@ DEPENDENCIES
   database_cleaner
   devise
   factory_girl_rails (= 1.4.0)
+  friendly_id
   gravatar-ultimate
   haml-rails
   i18n_routing

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -1,5 +1,8 @@
 class Idea < ActiveRecord::Base
   include PublishingStateMachine
+  extend FriendlyId
+
+  friendly_id :title, use: :slugged
 
   has_many :comments, as: :commentable
   has_many :votes

--- a/db/migrate/20120229153530_add_friendly_id_to_idea.rb
+++ b/db/migrate/20120229153530_add_friendly_id_to_idea.rb
@@ -1,0 +1,6 @@
+class AddFriendlyIdToIdea < ActiveRecord::Migration
+  def change
+    add_column :ideas, :slug, :string
+    add_index :ideas, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120229113917) do
+ActiveRecord::Schema.define(:version => 20120229153530) do
 
   create_table "administrators", :force => true do |t|
     t.string   "email"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(:version => 20120229113917) do
 
   add_index "administrators", ["email"], :name => "index_administrators_on_email", :unique => true
   add_index "administrators", ["reset_password_token"], :name => "index_administrators_on_reset_password_token", :unique => true
-
 
   create_table "articles", :force => true do |t|
     t.string   "title"
@@ -105,11 +104,13 @@ ActiveRecord::Schema.define(:version => 20120229113917) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "summary"
+    t.string   "slug"
     t.string   "publish_state", :default => "published"
   end
 
   add_index "ideas", ["author_id"], :name => "index_ideas_on_author_id"
   add_index "ideas", ["publish_state"], :name => "index_ideas_on_publish_state"
+  add_index "ideas", ["slug"], :name => "index_ideas_on_slug", :unique => true
 
   create_table "profiles", :force => true do |t|
     t.integer  "citizen_id"


### PR DESCRIPTION
This adds the FriendlyId gem and changes idea page URLs to use it. An example
URL looks as follows now:

  http://localhost:3000/ideat/esimerkki-idea-19

Signed-off-by: Pekka Enberg penberg@kernel.org
