### PR TITLE
Implements Citizen administration to admin views

### DIFF
--- a/app/assets/stylesheets/admin/citizens.css.scss
+++ b/app/assets/stylesheets/admin/citizens.css.scss
@@ -1,0 +1,7 @@
+table.citizens td.citizen_image {
+  width: 32px;
+}
+
+table.citizens h3.email {
+  font-weight: normal;
+}

--- a/app/controllers/admin/citizens_controller.rb
+++ b/app/controllers/admin/citizens_controller.rb
@@ -1,0 +1,7 @@
+class Admin::CitizensController < Admin::AdminController
+  respond_to :html
+  
+  def index
+    respond_with @citizens = Citizen.all
+  end
+end

--- a/app/controllers/admin/citizens_controller.rb
+++ b/app/controllers/admin/citizens_controller.rb
@@ -1,7 +1,29 @@
 class Admin::CitizensController < Admin::AdminController
   respond_to :html
   
+  before_filter :build_resource, except: [ :index ]
+  
   def index
     respond_with @citizens = Citizen.all
+  end
+  
+  def show
+    respond_with @citizen
+  end
+  
+  def lock
+    @citizen.lock!
+    redirect_to :back
+  end
+  
+  def unlock
+    @citizen.unlock!
+    redirect_to :back
+  end
+  
+  private
+  
+  def build_resource
+    @citizen = Citizen.find(params[:id])
   end
 end

--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -26,6 +26,10 @@ class Citizen < ActiveRecord::Base
   def image
     profile.image || Gravatar.new(email).image_url
   end
+  
+  def active_for_authentication?
+    super && !locked_at
+  end
 
   def self.find_for_facebook_auth(auth_hash)
     auth = Authentication.where(provider: auth_hash[:provider], uid: auth_hash[:uid]).first

--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -30,6 +30,18 @@ class Citizen < ActiveRecord::Base
   def active_for_authentication?
     super && !locked_at
   end
+  
+  def locked?
+    !!locked_at
+  end
+  
+  def lock!
+    update_attribute(:locked_at, Time.now)
+  end
+  
+  def unlock!
+    update_attribute(:locked_at, nil)
+  end
 
   def self.find_for_facebook_auth(auth_hash)
     auth = Authentication.where(provider: auth_hash[:provider], uid: auth_hash[:uid]).first

--- a/app/views/admin/citizens/index.html.haml
+++ b/app/views/admin/citizens/index.html.haml
@@ -1,7 +1,7 @@
 .row-fluid
   .span12
     %h1 Käyttäjät
-    %table.table.table-striped
+    %table.table.table-striped.citizens
       %thead
         %tr
           %th 
@@ -10,16 +10,14 @@
           %th
       %tbody
         - @citizens.each do |citizen|
-          %tr
+          %tr[citizen]
+            %td.citizen_image
+              = image_tag(citizen.image, width: 32, height: 32)
             %td
-              = image_tag(citizen.image)
+              %h3.name= link_to citizen.name, [:admin, citizen]
             %td
-              = citizen.name
-            %td
-              = citizen.email
+              %h3.email= citizen.email
             %td
               .btn-group{ style: "float: right"}
-                = link_to "Julkaise", [:publish, :admin, comment], class: "btn btn-success" if citizen.locked?
-                = link_to "Moderoi", [:moderate, :admin, comment], class: "btn btn-inverse"
-                = link_to "Piilota", [:unpublish, :admin, comment], class: "btn btn-danger"
-                = link_to "Moderoi", [:moderate, :admin, comment], class: "btn btn-inverse"
+                = link_to "Lukitse", [:lock, :admin, citizen], class: "btn btn-success" unless citizen.locked?
+                = link_to "Vapauta", [:unlock, :admin, citizen], class: "btn btn-inverse" if citizen.locked?

--- a/app/views/admin/citizens/index.html.haml
+++ b/app/views/admin/citizens/index.html.haml
@@ -1,0 +1,25 @@
+.row-fluid
+  .span12
+    %h1 Käyttäjät
+    %table.table.table-striped
+      %thead
+        %tr
+          %th 
+          %th Nimi
+          %th Sähköpostiosoite
+          %th
+      %tbody
+        - @citizens.each do |citizen|
+          %tr
+            %td
+              = image_tag(citizen.image)
+            %td
+              = citizen.name
+            %td
+              = citizen.email
+            %td
+              .btn-group{ style: "float: right"}
+                = link_to "Julkaise", [:publish, :admin, comment], class: "btn btn-success" if citizen.locked?
+                = link_to "Moderoi", [:moderate, :admin, comment], class: "btn btn-inverse"
+                = link_to "Piilota", [:unpublish, :admin, comment], class: "btn btn-danger"
+                = link_to "Moderoi", [:moderate, :admin, comment], class: "btn btn-inverse"

--- a/app/views/admin/citizens/show.html.haml
+++ b/app/views/admin/citizens/show.html.haml
@@ -1,0 +1,29 @@
+.row-fluid
+  .span12
+    %h3
+      KÄYTTÄJÄ
+    .row-fluid
+      .span1
+        = image_tag(@citizen.image)
+      %h1.name
+        = @citizen.name
+
+    .btn-group
+      = link_to "Lukitse", [:lock, :admin, @citizen], class: "btn btn-danger" unless @citizen.locked?
+      = link_to "Vapauta", [:unlock, :admin, @citizen], class: "btn btn-inverse" if @citizen.locked?
+    
+    .citizen-ideas
+      %h2 Ideat
+      %ul.ideas
+        = list_of @citizen.ideas do |idea|
+          = link_to idea.title, [:admin, idea]
+    
+    .citizen-comments
+      %h2 Kommentit
+      %ul.comments
+        = list_of @citizen.comments do |comment|
+          = link_to [:admin, comment] do
+            %h5= truncate(comment.body, length: 200)
+            %p
+              IDEA:
+              = comment.commentable.title

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -20,5 +20,6 @@
           %li= link_to "Ideat", admin_ideas_path
           %li= link_to "Kommentit", admin_comments_path
           %li= link_to "Kansalaiset", admin_citizens_path
+          %li= link_to "Kirjaudu ulos", destroy_administrator_session_path, method: :delete
   .container-fluid{ style: "padding-top: 50px" }
     = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ AvoinMinisterio::Application.routes.draw do
 
   devise_for :administrators
   
+  match "/admin", to: "admin/ideas#index", as: :administrator_root
   namespace :admin do
     resources :ideas do
       get "publish",    on: :member
@@ -30,7 +31,10 @@ AvoinMinisterio::Application.routes.draw do
       get "unpublish",  on: :member
       get "moderate",   on: :member
     end
-    resources :citizens
+    resources :citizens do
+      get "lock",       on: :member
+      get "unlock",     on: :member
+    end
     
     root to: "admin/ideas#index"
   end

--- a/db/migrate/20120229203252_add_locked_at_to_citizens.rb
+++ b/db/migrate/20120229203252_add_locked_at_to_citizens.rb
@@ -1,0 +1,5 @@
+class AddLockedAtToCitizens < ActiveRecord::Migration
+  def change
+    add_column :citizens, :locked_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120229153530) do
+ActiveRecord::Schema.define(:version => 20120229203252) do
 
   create_table "administrators", :force => true do |t|
     t.string   "email"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(:version => 20120229153530) do
     t.integer  "citizen_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "publish_state", :default => "unpublished"
   end
 
   create_table "authentications", :force => true do |t|
@@ -76,6 +77,7 @@ ActiveRecord::Schema.define(:version => 20120229153530) do
     t.string   "last_name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "locked_at"
   end
 
   add_index "citizens", ["email"], :name => "index_citizens_on_email", :unique => true
@@ -104,8 +106,8 @@ ActiveRecord::Schema.define(:version => 20120229153530) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "summary"
-    t.string   "slug"
     t.string   "publish_state", :default => "published"
+    t.string   "slug"
   end
 
   add_index "ideas", ["author_id"], :name => "index_ideas_on_author_id"


### PR DESCRIPTION
Citizens can be viewed in the admin views. The content they have authored is displayed on the admin/citizens#show page.

Offending accounts can be locked and repented offenders can be allowed to log in by unlocking the account.
