### PR TITLE
Fix missing translations

### DIFF
--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,10 +1,14 @@
 fi:
   resources:
+    articles: "artikkelit"
     citizens: "kansalaiset"
+    comments: "kommentit"
     ideas: "ideat"
   activerecord:
     models:
+      article: "Artikkeli"
       citizen: "Kansalainen"
+      comment: "Kommentti"
       idea: "Idea"
       profile: "Profiili"
     attributes:


### PR DESCRIPTION
This patch adds some missing translation which fixes a funny

  "Luo comment"

buttom text on idea page.

Signed-off-by: Pekka Enberg penberg@kernel.org
