### PR TITLE
Ensure the agent is started using Unicorn

### DIFF
--- a/config/initializers/newrelic.rb
+++ b/config/initializers/newrelic.rb
@@ -1,0 +1,4 @@
+# Ensure the agent is started using Unicorn
+# This is needed when using Unicorn and preload_app is not set to true.
+# See https://newrelic.com/docs/troubleshooting/im-using-unicorn-and-i-dont-see-any-data
+NewRelic::Agent.after_fork(:force_reconnect => true) if defined? Unicorn


### PR DESCRIPTION
This is needed when using Unicorn and preload_app is not set to true.
See https://newrelic.com/docs/troubleshooting/im-using-unicorn-and-i-dont-see-any-data
