### PR TITLE
Moves all publish_state related class methods to PublishingStateMachine ...

### DIFF
--- a/app/concerns/publishing_state_machine.rb
+++ b/app/concerns/publishing_state_machine.rb
@@ -6,14 +6,26 @@ module PublishingStateMachine
       event :publish do
         transition [ :in_moderation, :unpublished ] => :published
       end
-    
+
       event :unpublish do
         transition [ :published ] => :unpublished
       end
-    
+
       event :moderate do
         transition [ :published ] => :in_moderation
-      end    
+      end
+    end
+
+    def self.published
+      where(publish_state: "published")
+    end
+
+    def self.unpublished
+      where(publish_state: "unpublished")
+    end
+
+    def self.in_moderation
+      where(publish_state: "in_moderation")
     end
   end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -35,16 +35,4 @@ class Idea < ActiveRecord::Base
   def vote_counts
     votes.group(:option).count
   end
-
-  def self.published
-    where(publish_state: "published")
-  end
-
-  def self.unpublished
-    where(publish_state: "unpublished")
-  end
-
-  def self.in_moderation
-    where(publish_state: "in_moderation")
-  end
 end


### PR DESCRIPTION
...so that they'll be available for all classes that include the module.
