### PR TITLE
Changelogs for ideas comments and articles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "redcarpet"
 gem "simple_form"
 gem "state_machine"
 gem "will_paginate", "~> 3.0"
+gem "differ"
 
 gem "rspec-rails", :groups => [ :development, :test ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       orm_adapter (~> 0.0.3)
       warden (~> 1.1)
     diff-lcs (1.1.3)
+    differ (0.1.2)
     erubis (2.7.0)
     execjs (1.2.13)
       multi_json (~> 1.0)
@@ -220,6 +221,7 @@ DEPENDENCIES
   coffee-rails (~> 3.1.1)
   database_cleaner
   devise
+  differ
   factory_girl_rails (= 1.4.0)
   friendly_id
   gravatar-ultimate

--- a/app/assets/stylesheets/admin/changelogs.css.scss
+++ b/app/assets/stylesheets/admin/changelogs.css.scss
@@ -1,0 +1,28 @@
+del.differ {
+  text-decoration: none;
+  background: #ffcccc;
+}
+ins.differ {
+  text-decoration: none;
+  background: #ccffcc;
+}
+
+table.changelogs {
+  tr > td { padding: 3px; }
+  tr.changelog {
+    border-bottom: 1px solid #ddd;
+    td.changes {
+      table {
+        width: 100%;
+        tr { border-bottom: 1px solid #ddd; }
+        tr > td.field { width: 80px; }
+        tr > td { padding: 3px; }
+      }
+    }
+  }
+  tr.changelog:hover {
+    background: #fafafa;
+  }
+  tr.odd { background: #fff; }
+  tr.even { background: #eee; }
+}

--- a/app/assets/stylesheets/admin/changelogs.css.scss
+++ b/app/assets/stylesheets/admin/changelogs.css.scss
@@ -8,10 +8,13 @@ ins.differ {
 }
 
 table.changelogs {
-  tr > td { padding: 3px; }
+  tr > td { vertical-align: top; padding: 3px; }
   tr.changelog {
     border-bottom: 1px solid #ddd;
+    td.changer > img { line-height: 18px; vertical-align: middle; }
+    td.changer > span.name { line-height: 18px; }
     td.changes {
+      vertical-align: top;
       table {
         width: 100%;
         tr { border-bottom: 1px solid #ddd; }
@@ -25,4 +28,10 @@ table.changelogs {
   }
   tr.odd { background: #fff; }
   tr.even { background: #eee; }
+}
+
+span.admin {
+  color: #aa4444;
+  font-size: 11px;
+  font-weight: bolder;
 }

--- a/app/concerns/changelogger.rb
+++ b/app/concerns/changelogger.rb
@@ -6,7 +6,7 @@ module Changelogger
 
     after_create { changelog_for!(:create) }
     before_update { changelog_for!(:update) }
-    after_destroy { changelog_for!(:destroy) }
+    before_destroy { changelog_for!(:destroy) }
 
     def changelog_for!(action)
       self.changelogs.create!(

--- a/app/concerns/changelogger.rb
+++ b/app/concerns/changelogger.rb
@@ -10,6 +10,7 @@ module Changelogger
 
     def changelog_for!(action)
       self.changelogs.create!(
+          changer: Thread.current[:changer], # not actually thread-safe, but enough for our needs
           changelogged_type: self.class,
           changelogged_id: self.id,
           change_type: action,

--- a/app/concerns/changelogger.rb
+++ b/app/concerns/changelogger.rb
@@ -1,0 +1,20 @@
+module Changelogger
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :changelogs, as: :changelogged
+
+    after_create { changelog_for!(:create) }
+    before_update { changelog_for!(:update) }
+    after_destroy { changelog_for!(:destroy) }
+
+    def changelog_for!(action)
+      self.changelogs.create!(
+          changelogged_type: self.class,
+          changelogged_id: self.id,
+          change_type: action,
+          attribute_changes: self.changes.to_yaml
+        )
+    end
+  end
+end

--- a/app/controllers/admin/changelogs_controller.rb
+++ b/app/controllers/admin/changelogs_controller.rb
@@ -1,0 +1,10 @@
+require 'differ/string'
+
+class Admin::ChangelogsController < Admin::AdminController
+  respond_to :html
+
+  def index
+    @changelogs = Changelog.paginate(page: params[:page]).order('created_at DESC')
+    respond_with @changelogs
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_filter :set_locale
   before_filter :set_locale_from_url
+  before_filter :set_changer
 
   def after_sign_in_path_for(resource)
       return request.env['omniauth.origin'] || stored_location_for(resource) || root_path
@@ -12,5 +13,9 @@ class ApplicationController < ActionController::Base
 
   def set_locale
     I18n.locale = params[:locale] || ((lang = request.env['HTTP_ACCEPT_LANGUAGE']) && lang[/^[a-z]{2}/])
+  end
+
+  def set_changer
+    Thread.current[:changer] = current_citizen || current_administrator
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_changer
-    Thread.current[:changer] = current_citizen || current_administrator
+    Thread.current[:changer] = current_administrator || current_citizen
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,7 @@
 class Article < ActiveRecord::Base
   include PublishingStateMachine
-  
+  include Changelogger
+
   belongs_to :idea
   belongs_to :author, class_name: "Citizen", foreign_key: "citizen_id"
 end

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -2,10 +2,8 @@ class Changelog < ActiveRecord::Base
   belongs_to :changer, polymorphic: true
   belongs_to :changelogged, polymorphic: true
 
-  default_scope order(created_at: :desc)
-
   def self.per_page
-    100
+    50
   end
 
   def attribute_changes

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -2,6 +2,12 @@ class Changelog < ActiveRecord::Base
   belongs_to :changer, polymorphic: true
   belongs_to :changelogged, polymorphic: true
 
+  default_scope order(created_at: :desc)
+
+  def self.per_page
+    100
+  end
+
   def attribute_changes
     YAML.load read_attribute(:attribute_changes)
   end

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -1,7 +1,6 @@
 class Changelog < ActiveRecord::Base
-  belongs_to :idea, polymorphic: true
-  belongs_to :comment, polymorphic: true
-  belongs_to :article, polymorphic: true
+  belongs_to :changer, polymorphic: true
+  belongs_to :changelogged, polymorphic: true
 
   def attribute_changes
     YAML.load read_attribute(:attribute_changes)

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -1,0 +1,9 @@
+class Changelog < ActiveRecord::Base
+  belongs_to :idea, polymorphic: true
+  belongs_to :comment, polymorphic: true
+  belongs_to :article, polymorphic: true
+
+  def attribute_changes
+    YAML.load read_attribute(:attribute_changes)
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ActiveRecord::Base
   include PublishingStateMachine
+  include Changelogger
 
   belongs_to :author, class_name: "Citizen", foreign_key: "author_id"
   belongs_to :commentable, polymorphic: true

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -1,5 +1,6 @@
 class Idea < ActiveRecord::Base
   include PublishingStateMachine
+  include Changelogger
   extend FriendlyId
 
   MAX_FB_TITLE_LENGTH = 100

--- a/app/views/admin/changelogs/_changelog.html.haml
+++ b/app/views/admin/changelogs/_changelog.html.haml
@@ -1,20 +1,26 @@
 %tr.changelog
   %td.changer
-    - if changelog.changer.class == Citizen
-      = image_tag changelog.changer.image, width: 18, height: 18
-    %span.name
-      - if changelog.changer.class == Administrator
-        = changelog.changer.email
-        %span.admin (admin)
-      - else
-        = changelog.changer.name
+    - unless changelog.changer
+      %span.name Tuntematon, luultavasti Rails-konsolista
+    - else
+      - if changelog.changer.class == Citizen
+        = image_tag changelog.changer.image, width: 18, height: 18
+      %span.name
+        - if changelog.changer.class == Administrator
+          = changelog.changer.email
+          %span.admin (admin)
+        - else
+          = changelog.changer.name
   %td.change_type
     = I18n.t "changelog.#{changelog.change_type}"
   %td.changed_at
     %span.date{title: finnishTime(changelog.created_at).split(' ').reverse.join(' ')}
       = finnishTime(changelog.created_at).split(' ').last
   %td.changelogged
-    = link_to "#{I18n.t('activerecord.models.'+changelog.changelogged_type.downcase)} ( ##{changelog.changelogged_id} )", changelog.changelogged
+    - if changelog.changelogged
+      = link_to "#{I18n.t('activerecord.models.'+changelog.changelogged_type.downcase)} ##{changelog.changelogged_id}", changelog.changelogged
+    - else
+      = "#{I18n.t('activerecord.models.'+changelog.changelogged_type.downcase)} ##{changelog.changelogged_id}<br/> ( poistettu )".html_safe
   %td.changes
     %table
       %tr

--- a/app/views/admin/changelogs/_changelog.html.haml
+++ b/app/views/admin/changelogs/_changelog.html.haml
@@ -1,0 +1,28 @@
+%tr.changelog
+  %td.changer
+    %span.name TODO
+  %td.change_type
+    = I18n.t "changelog.#{changelog.change_type}"
+  %td.changed_at
+    %span.date
+      = finnishTime(changelog.created_at).split(' ').join('<br/>').html_safe
+  %td.changelogged
+    = link_to "#{I18n.t('activerecord.models.'+changelog.changelogged_type.downcase)} ( ##{changelog.changelogged_id} )", changelog.changelogged
+  %td.changes
+    %table
+      %tr
+        %td Kenttä
+        %td Muutos
+        %td Vanha arvo
+        %td Uusi arvo
+      - changelog.attribute_changes.each_pair do |changed_field, change|
+        - next if ["created_at", "updated_at", "id"].include?(changed_field)
+        %tr
+          %td.field
+            = changed_field
+          %td.span4.diff
+            = Differ.diff(change.last.to_s, change.first.to_s, 'i').to_s.html_safe
+          %td.span3.old
+            = change.first
+          %td.span3.new
+            = change.last

--- a/app/views/admin/changelogs/_changelog.html.haml
+++ b/app/views/admin/changelogs/_changelog.html.haml
@@ -1,11 +1,18 @@
 %tr.changelog
   %td.changer
-    %span.name TODO
+    - if changelog.changer.class == Citizen
+      = image_tag changelog.changer.image, width: 18, height: 18
+    %span.name
+      - if changelog.changer.class == Administrator
+        = changelog.changer.email
+        %span.admin (admin)
+      - else
+        = changelog.changer.name
   %td.change_type
     = I18n.t "changelog.#{changelog.change_type}"
   %td.changed_at
-    %span.date
-      = finnishTime(changelog.created_at).split(' ').join('<br/>').html_safe
+    %span.date{title: finnishTime(changelog.created_at).split(' ').reverse.join(' ')}
+      = finnishTime(changelog.created_at).split(' ').last
   %td.changelogged
     = link_to "#{I18n.t('activerecord.models.'+changelog.changelogged_type.downcase)} ( ##{changelog.changelogged_id} )", changelog.changelogged
   %td.changes

--- a/app/views/admin/changelogs/index.html.haml
+++ b/app/views/admin/changelogs/index.html.haml
@@ -1,0 +1,13 @@
+.changelogs_header.container_24
+  %h1.grid_24 Muutokset
+= will_paginate @changelogs
+.changelogs.container_24
+  %table.changelogs
+    %thead
+      %th.span2 Muutoksen tekijä
+      %th{style: "width: 60px;"} 
+      %th.span1 Aika
+      %th.span2 Muutoksen kohde
+      %th.span10 Muutokset
+    = render partial: 'changelog', collection: @changelogs
+= will_paginate @changelogs

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -20,6 +20,7 @@
           %li= link_to "Ideat", admin_ideas_path
           %li= link_to "Kommentit", admin_comments_path
           %li= link_to "Kansalaiset", admin_citizens_path
+          %li= link_to "Muutosloki", admin_changelogs_path
           %li= link_to "Kirjaudu ulos", destroy_administrator_session_path, method: :delete
   .container-fluid{ style: "padding-top: 50px" }
     = yield

--- a/config/initializers/differ.rb
+++ b/config/initializers/differ.rb
@@ -1,0 +1,1 @@
+Differ.format = :html

--- a/config/locales/admin.fi.yml
+++ b/config/locales/admin.fi.yml
@@ -1,0 +1,5 @@
+fi:
+  changelog:
+    create: "loi uuden"
+    update: "päivitti"
+    destroy: "poisti"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,6 @@ AvoinMinisterio::Application.routes.draw do
       get "unpublish",  on: :member
       get "moderate",   on: :member
     end
-    resources :citizens
     resources :comments do
       get "publish",    on: :member
       get "unpublish",  on: :member
@@ -48,6 +47,7 @@ AvoinMinisterio::Application.routes.draw do
       get "lock",       on: :member
       get "unlock",     on: :member
     end
+    resources :changelogs
     root to: "admin/ideas#index"
   end
 

--- a/db/migrate/20120304000619_create_changelogs.rb
+++ b/db/migrate/20120304000619_create_changelogs.rb
@@ -1,6 +1,8 @@
 class CreateChangelogs < ActiveRecord::Migration
   def change
     create_table :changelogs do |t|
+      t.string :changer_type
+      t.integer :changer_id
       t.string :changelogged_type
       t.integer :changelogged_id
       t.string :change_type
@@ -8,6 +10,7 @@ class CreateChangelogs < ActiveRecord::Migration
 
       t.timestamps
     end
+    add_index :changelogs, [:changer_type, :changer_id]
     add_index :changelogs, [:changelogged_type, :changelogged_id]
   end
 end

--- a/db/migrate/20120304000619_create_changelogs.rb
+++ b/db/migrate/20120304000619_create_changelogs.rb
@@ -1,0 +1,13 @@
+class CreateChangelogs < ActiveRecord::Migration
+  def change
+    create_table :changelogs do |t|
+      t.string :changelogged_type
+      t.integer :changelogged_id
+      t.string :change_type
+      t.text :attribute_changes
+
+      t.timestamps
+    end
+    add_index :changelogs, [:changelogged_type, :changelogged_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120229203252) do
+ActiveRecord::Schema.define(:version => 20120304000619) do
 
   create_table "administrators", :force => true do |t|
     t.string   "email"
@@ -61,6 +61,17 @@ ActiveRecord::Schema.define(:version => 20120229203252) do
   add_index "authentications", ["citizen_id"], :name => "index_authentications_on_citizen_id"
   add_index "authentications", ["provider", "uid"], :name => "index_authentications_on_provider_and_uid", :unique => true
 
+  create_table "changelogs", :force => true do |t|
+    t.string   "changelogged_type"
+    t.integer  "changelogged_id"
+    t.string   "change_type"
+    t.text     "attribute_changes"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "changelogs", ["changelogged_type", "changelogged_id"], :name => "index_changelogs_on_changelogged_type_and_changelogged_id"
+
   create_table "citizens", :force => true do |t|
     t.string   "email"
     t.string   "encrypted_password",     :limit => 128, :default => "", :null => false
@@ -101,7 +112,7 @@ ActiveRecord::Schema.define(:version => 20120229203252) do
   create_table "ideas", :force => true do |t|
     t.string   "title"
     t.text     "body"
-    t.string   "state"
+    t.string   "state",         :default => "idea"
     t.integer  "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,8 @@ ActiveRecord::Schema.define(:version => 20120304000619) do
   add_index "authentications", ["provider", "uid"], :name => "index_authentications_on_provider_and_uid", :unique => true
 
   create_table "changelogs", :force => true do |t|
+    t.string   "changer_type"
+    t.integer  "changer_id"
     t.string   "changelogged_type"
     t.integer  "changelogged_id"
     t.string   "change_type"
@@ -71,6 +73,7 @@ ActiveRecord::Schema.define(:version => 20120304000619) do
   end
 
   add_index "changelogs", ["changelogged_type", "changelogged_id"], :name => "index_changelogs_on_changelogged_type_and_changelogged_id"
+  add_index "changelogs", ["changer_type", "changer_id"], :name => "index_changelogs_on_changer_type_and_changer_id"
 
   create_table "citizens", :force => true do |t|
     t.string   "email"

--- a/spec/controllers/admin/changelogs_controller_spec.rb
+++ b/spec/controllers/admin/changelogs_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Admin::ArticlesController do
+describe Admin::ChangelogsController do
 
   before :each do
     @administrator = Factory(:administrator)

--- a/spec/controllers/admin/comments_controller_spec.rb
+++ b/spec/controllers/admin/comments_controller_spec.rb
@@ -2,4 +2,16 @@ require 'spec_helper'
 
 describe Admin::CommentsController do
 
+  before :each do
+    @administrator = Factory(:administrator)
+    sign_in :administrator, @administrator
+  end
+
+  describe "GET 'index'" do
+    it "returns http success" do
+      get 'index'
+      response.should be_success
+    end
+  end
+
 end

--- a/spec/controllers/admin/ideas_controller_spec.rb
+++ b/spec/controllers/admin/ideas_controller_spec.rb
@@ -2,4 +2,16 @@ require 'spec_helper'
 
 describe Admin::IdeasController do
 
+  before :each do
+    @administrator = Factory(:administrator)
+    sign_in :administrator, @administrator
+  end
+
+  describe "GET 'index'" do
+    it "returns http success" do
+      get 'index'
+      response.should be_success
+    end
+  end
+
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,6 +16,11 @@ FactoryGirl.define do
     association :profile
   end
 
+  factory :administrator do
+    email
+    password "ylläpitäjä"
+  end
+
   factory :erkki, :parent => :citizen do |e|
     email 'erkki@esimerkki.fi'
     first_name 'Erkki'

--- a/spec/models/changelog_spec.rb
+++ b/spec/models/changelog_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Changelog do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/modules/changelogger_spec.rb
+++ b/spec/modules/changelogger_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Changelogger do
+  module Connections
+    def self.extended(host)
+      host.connection.execute <<-eosql
+          CREATE TABLE #{host.table_name} (
+            #{host.primary_key} integer PRIMARY KEY AUTOINCREMENT,
+            associated_model_id integer,
+            mockable_model_id integer,
+            nonexistent_model_id integer,
+            title string
+          )
+        eosql
+    end
+  end
+
+  class ChangeloggableItem < ActiveRecord::Base
+    extend Connections
+    include Changelogger
+
+    # attr_accessor :title, :created_at, :updated_at
+  end
+
+  after :all do
+    ChangeloggableItem.connection.execute "DROP TABLE changeloggable_items"
+  end
+
+  before :each do
+    @item = ChangeloggableItem.new title: "Log me!"
+  end
+
+  it "should log creates" do
+    lambda {
+      @item.save!
+    }.should change(Changelog, :count).by(1)
+    cl = @item.changelogs.first
+    cl.changelogged.should == @item
+    cl.change_type.should == "create"
+    cl.attribute_changes['title'].should == [nil, "Log me!"]
+  end
+
+  it "should log updates" do
+    @item.save!
+    lambda {
+      @item.title = "I just got updated!"
+      @item.save!
+    }.should change(Changelog, :count).by(1)
+    cl = @item.changelogs.last
+    cl.change_type.should == "update"
+    cl.attribute_changes['title'].should == ["Log me!", "I just got updated!"]
+  end
+
+  it "should log destroys" do
+    @item.save!
+    lambda {
+      @item.destroy
+    }.should change(Changelog, :count).by(1)
+    cl = Changelog.last
+    cl.change_type.should == "destroy"
+    cl.attribute_changes.should == {}
+  end
+end

--- a/spec/modules/changelogger_spec.rb
+++ b/spec/modules/changelogger_spec.rb
@@ -60,4 +60,24 @@ describe Changelogger do
     cl.change_type.should == "destroy"
     cl.attribute_changes.should == {}
   end
+
+  it "should log a citizen changer" do
+    citizen = Factory(:citizen)
+    Thread.current[:changer] = citizen
+    lambda {
+      @item.save!
+    }.should change(Changelog, :count).by(1)
+    cl = Changelog.last
+    cl.changer.should == citizen
+  end
+
+  it "should log an administrator changer" do
+    administrator = Factory(:administrator)
+    Thread.current[:changer] = administrator
+    lambda {
+      @item.save!
+    }.should change(Changelog, :count).by(1)
+    cl = Changelog.last
+    cl.changer.should == administrator
+  end
 end

--- a/spec/modules/changelogger_spec.rb
+++ b/spec/modules/changelogger_spec.rb
@@ -6,9 +6,6 @@ describe Changelogger do
       host.connection.execute <<-eosql
           CREATE TABLE #{host.table_name} (
             #{host.primary_key} integer PRIMARY KEY AUTOINCREMENT,
-            associated_model_id integer,
-            mockable_model_id integer,
-            nonexistent_model_id integer,
             title string
           )
         eosql


### PR DESCRIPTION
Todo (already fixed): Changer name and profile image to the list. Currently it's not possible to get current_citizen or current_administrator in changelogged models' instances.

Todo 2 (also fixed ;): Really destroyed changeloggeds breaks the list at least in _changelog.html.haml on line 10 (where a link to the changelogged thing is created).
