### PR TITLE
Do not hard code http protocol for included content

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -65,7 +65,7 @@
           %a{:class => "addthis_button_compact"}
           %a{:class => "addthis_counter addthis_bubble_style"}
 
-  %script{:type => "text/javascript", :src => "http://s7.addthis.com/js/250/addthis_widget.js#pubid=xa-4f4e6d6b380c6e19"}
+  %script{:type => "text/javascript", :src => "//s7.addthis.com/js/250/addthis_widget.js#pubid=xa-4f4e6d6b380c6e19"}
 
   = render :partial => 'shared/ga' if ENV["GA_TRACKING_ID"]
 

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -43,7 +43,7 @@
 
 .grid_8.news.omega
   %h2 Ministeriössä tapahtuu
-  %iframe{width: "310", height: "192", src: "http://www.youtube.com/embed/R2wa2O0EBTg?rel=0", frameborder: "0", allowfullscreen: ""}
+  %iframe{width: "310", height: "192", src: "//www.youtube.com/embed/R2wa2O0EBTg?rel=0", frameborder: "0", allowfullscreen: ""}
   - if @front_page_articles.any?
     - @front_page_articles.each do |article|
       .news_item


### PR DESCRIPTION
Use '//' instead of 'http://' so that browsers do not complain about
mixed http/https content when accessed using https.
