### PR TITLE
Use id and slug in urls for ideas and articles.

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,4 +12,8 @@ class Article < ActiveRecord::Base
 
   validates :article_type, inclusion: { in: VALID_ARTICLE_TYPES }
   validates :title, length: { minimum: 5 }
+
+  def to_param
+    "#{self.id}-#{self.slug}"
+  end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -26,6 +26,10 @@ class Idea < ActiveRecord::Base
     25
   end
 
+  def to_param
+    "#{self.id}-#{self.slug}"
+  end
+
   def vote(citizen, option)
     vote = votes.by(citizen).first
     KM.identify(citizen)

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,7 +1,7 @@
 .grid_24
   .idea_author
-    %img{ src: @article.author.image, width: 48, height: 48 }
     - if @article.author
+      %img{ src: @article.author.image, width: 48, height: 48 }
       %span= @article.author.name
     - else
       %span= No author

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ AvoinMinisterio::Application.routes.draw do
   resources :ideas do
     resources :comments
   end
-  resources :articles
+  resources :articles do
+    resources :comments
+  end
 
   devise_for :administrators
   

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,5 +1,25 @@
 require 'spec_helper'
 
 describe ArticlesController do
+  render_views
 
+  describe "#show" do
+    before :each do
+      @article = Factory :article
+    end
+
+    it "should show an article" do
+      get :show, id: @article.id
+      response.body.should include(@article.title)
+      response.body.should include(@article.author.name)
+      response.body.should include("Article body")
+    end
+
+    it "should show an article with slugged url" do
+      get :show, id: "#{@article.id}-#{@article.slug}"
+      response.body.should include(@article.title)
+      response.body.should include(@article.author.name)
+      response.body.should include("Article body")
+    end
+  end
 end

--- a/spec/controllers/ideas_controller_spec.rb
+++ b/spec/controllers/ideas_controller_spec.rb
@@ -9,11 +9,18 @@ describe IdeasController do
 
   describe "#show" do
     before :each do
-      @idea = Factory.create :idea
+      @idea = Factory :idea
     end
 
     it "should show an idea" do
       get :show, id: @idea.id
+      response.body.should include(@idea.title)
+      response.body.should include(@idea.author.name)
+      response.body.should include("Tehdäänkö tästä laki?")
+    end
+
+    it "should show an idea with slugged url" do
+      get :show, id: "#{@idea.id}-#{@idea.slug}"
       response.body.should include(@idea.title)
       response.body.should include(@idea.author.name)
       response.body.should include("Tehdäänkö tästä laki?")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -66,7 +66,7 @@ FactoryGirl.define do
 
   factory :article do
     article_type  'statement'
-    title
+    title         'Article title'
     ingress       'Article ingress'
     body          'Article body'
     association :idea, factory: :idea

--- a/spec/helpers/admin/changelogs_helper_spec.rb
+++ b/spec/helpers/admin/changelogs_helper_spec.rb
@@ -34,27 +34,27 @@ EOS
     it "should build a link for an Idea" do
       idea = Factory :idea
       link = helper.changelogged_link_for(idea.changelogs.last)
-      link.should include("<a href=\"/ideat/#{idea.slug}\">Idea ##{idea.id}</a>")
+      link.should include("<a href=\"/ideat/#{idea.to_param}\">Idea ##{idea.id}</a>")
     end
 
     it "should build a link for an Idea comment" do
       idea = Factory :idea
       comment = Factory :comment, commentable: idea
       link = helper.changelogged_link_for(comment.changelogs.last)
-      link.should include("<a href=\"/ideat/#{idea.slug}#comments\">Kommentti ##{comment.id}</a>")
+      link.should include("<a href=\"/ideat/#{idea.to_param}#comments\">Kommentti ##{comment.id}</a>")
     end
 
     it "should build a link for an Article" do
       article = Factory :article
       link = helper.changelogged_link_for(article.changelogs.last)
-      link.should include("<a href=\"/artikkelit/#{article.slug}\">Artikkeli ##{article.id}</a>")
+      link.should include("<a href=\"/artikkelit/#{article.to_param}\">Artikkeli ##{article.id}</a>")
     end
 
     it "should build a link for an Article comment" do
       article = Factory :article
       comment = Factory :comment, commentable: article
       link = helper.changelogged_link_for(comment.changelogs.last)
-      link.should include("<a href=\"/artikkelit/#{article.slug}#comments\">Kommentti ##{comment.id}</a>")
+      link.should include("<a href=\"/artikkelit/#{article.to_param}#comments\">Kommentti ##{comment.id}</a>")
     end
   end
 end

--- a/spec/routing/articles_routes_spec.rb
+++ b/spec/routing/articles_routes_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "articles resource routes" do
+  describe "#show" do
+    it "routes /artikkelit/:article.slug to ArticlesController#show" do
+      { get: 'http://localhost/artikkelit/uusi-artikkeli' }.should route_to(
+        locale: 'fi',
+        controller: 'articles',
+        action: 'show',
+        id: 'uusi-artikkeli'
+      )
+    end
+
+    it "routes /artikkelit/:article.id-:article.slug to ArticlesController#show" do
+      { get: 'http://localhost/artikkelit/1-uusi-artikkeli' }.should route_to(
+        locale: 'fi',
+        controller: 'articles',
+        action: 'show',
+        id: '1-uusi-artikkeli'
+      )
+    end
+  end
+end

--- a/spec/routing/comments_routes_spec.rb
+++ b/spec/routing/comments_routes_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "comments resource routes" do
+  describe "#create" do
+    it "routes /ideat/:idea.id-:idea.slug/kommentit to CommentsController#create" do
+      { post: 'http://localhost/ideat/123-allow-citizen-initiatives/kommentit' }.should route_to(
+        locale: 'fi',
+        controller: 'comments',
+        idea_id: '123-allow-citizen-initiatives',
+        action: 'create'
+      )
+    end
+
+    it "routes /artikkelit/:article.id-:article.slug/kommentit to IdeasController#show" do
+      { post: 'http://localhost/artikkelit/321-allow-citizen-initiatives/kommentit' }.should route_to(
+        locale: 'fi',
+        controller: 'comments',
+        article_id: '321-allow-citizen-initiatives',
+        action: 'create'
+      )
+    end
+  end
+end

--- a/spec/routing/ideas_routes_spec.rb
+++ b/spec/routing/ideas_routes_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "ideas resource routes" do
+  describe "#show" do
+    it "routes /ideat/:idea.slug to IdeasController#show" do
+      { get: 'http://localhost/ideat/allow-citizen-initiatives' }.should route_to(
+        locale: 'fi',
+        controller: 'ideas',
+        action: 'show',
+        id: 'allow-citizen-initiatives'
+      )
+    end
+
+    it "routes /ideat/:idea.id-:idea.slug to IdeasController#show" do
+      { get: 'http://localhost/ideat/123-allow-citizen-initiatives' }.should route_to(
+        locale: 'fi',
+        controller: 'ideas',
+        action: 'show',
+        id: '123-allow-citizen-initiatives'
+      )
+    end
+  end
+end


### PR DESCRIPTION
The old urls having only a slug will work as long as the current title isn't changed.
The urls for resources created after this patch will work infinitely, as the id in the beginning of the url is used to find the according resource.

Ps. ignore article comments thing, I noticed too late that we don't have that feature yet. As they are going to be reality at some point, I kept the code in place for reference.
