### PR TITLE
Fixed so that only published comments are shown

### DIFF
--- a/app/views/ideas/show.html.haml
+++ b/app/views/ideas/show.html.haml
@@ -88,4 +88,4 @@
   .grid_24.comment_form
     = render "comments/form", model: @idea
   .comments.suffix_8
-    = render partial: 'comments/comment', collection: @idea.comments
+    = render partial: 'comments/comment', collection: @idea.comments.find_all{|c| c.published?}


### PR DESCRIPTION
Fixes the problem that in Admin panel a comment can be hidden ("unpublish") but all comments are shown anyway. Now only published comments are presented, so admins can effectively hide comments.

This probably should be refactored into Ideal model, or helpers or such. However, as the test is done for each member of the collection instead of the single associated model, I didn't knew how the refactoring would be best to do. This worked however.

Also, this naturally needs real tests to reflect the intended meaning (only non-hidden comments should be presented to user). Again, my tests are failing due to other work-in-progress so I couldn't run the tests at all. Another thing to fix. This was just an urgent fix.
