### PR TITLE
Disables comment form submit button after the form is submitted

### DIFF
--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -6,6 +6,6 @@
       = f.input :body, as: :text, label: false, disabled: true, input_html: { :class => 'disabled', value: "Voit kirjoittaa kommentteja kirjautumalla sisään"}
   .grid_8.omega
     - if citizen_signed_in?
-      = f.submit "Lisää kommentti"
+      = f.submit "Lisää kommentti", disable_with: "Lähetetään ..."
     - else
       = f.submit "Lisää kommentti", disabled: true, input_html: { :class => 'disabled' }


### PR DESCRIPTION
This fix prevents duplicate comments from double clicking, etc. client user actions.
