### PR TITLE
Move comment counts into bubbles in the main page

### DIFF
--- a/app/assets/stylesheets/ideas.css.scss
+++ b/app/assets/stylesheets/ideas.css.scss
@@ -139,6 +139,23 @@ h2 {
   text-transform: uppercase;
 }
 
+.front-page-comment-count {
+  display: inline-block;
+  width: 42px;
+  padding: 2px 6px 0 0;
+  height: 32px;
+  margin: 0 10px 0 20px;
+  background: transparent url("/assets/comment-bg.png") top left no-repeat;
+  text-align: right;
+  color: #fff;
+  font-size: 13px;
+  font-weight: bold;
+  font-family: "Segoe WP", "Lucida Grande", "Lucida Sans", sans-serif;
+  a {
+    color: rgb(10, 50, 70);
+  }
+}
+
 .idea_comments {
   .comment {
     margin-bottom: 10px;

--- a/app/views/pages/_ideas.html.haml
+++ b/app/views/pages/_ideas.html.haml
@@ -14,6 +14,6 @@
         %span.for #{for_}
         |
         %span.against #{against}
-        %span.comments= link_to "#{comments} kommenttia", idea_path(idea, anchor: "comments")
+        %span.front-page-comment-count= link_to "#{comments}", idea_path(idea, anchor: "comments")
 
   =link_to "Listaa kaikki»", ideas_path, class: "list_ideas"


### PR DESCRIPTION
This commit moves comment counts in the main page into bubbles (as in the ideas page).

I retained links to comments. To keep them readable, I darkened their color. To make it clear that they are still links, I restored underlining.

I created a separate CSS class for the bubbles. It was the safest way to change their look.

Tested in Opera, Firefox, rekonq and Konqueror.
