### PR TITLE
Move article counts into bubbles in the idea list

### DIFF
--- a/app/assets/stylesheets/ideas.css.scss
+++ b/app/assets/stylesheets/ideas.css.scss
@@ -287,7 +287,7 @@ ul.horizontal li {
   width: 42px;
   padding: 2px 6px 0 0;
   height: 32px;
-  margin: 0 10px 0 20px;
+  margin: 0 5px 0 20px;
   background: transparent url("/assets/comment-bg.png") top left no-repeat;
   text-align: right;
   color: #fff;
@@ -305,8 +305,15 @@ ul.horizontal li {
   color: $red;
 }
 
-.stats .articles{
-  color: $grey;
+.stats span.article-count {
+  display: inline-block;
+  width: 32px;
+  padding: 2px 6px 0 0;
+  height: 26px;
+  margin: 0 5px 0 5px;
+  background: transparent url("/assets/asiantuntijalausunnot.png") top left no-repeat;
+  text-align: right;
+  color: #fff;
 }
 
 .prevnext .right {

--- a/app/views/ideas/index.html.haml
+++ b/app/views/ideas/index.html.haml
@@ -69,7 +69,5 @@
           %span.against= sprintf("%.0f%%", (1.0-for_)*100.0)
           %span.comment-count= (idea.comment_count || 0)
           -if idea.articles.count > 0
-            %span.articles
-              = idea.articles.count
-              = (idea.articles.count == 1 ? "lausunto" : "lausuntoa")
+            %span.article-count= idea.articles.count
 = will_paginate @ideas


### PR DESCRIPTION
This commit moves article counts in the idea list into bubbles (like the comment counts).

I reduced the right margin of span.comment-count, because otherwise the bubbles were too far from each other.

The article count still isn't displayed if there are no articles. To test the layout, I temporarily forced the counts to be always visible. I haven't committed that code. (It only affects two lines anyway.)

Layout tested in Opera, Firefox, rekonq and Konqueror.
