### PR TITLE
Change the string which requests visitors to sign a proposal

### DIFF
--- a/app/views/ideas/show.html.haml
+++ b/app/views/ideas/show.html.haml
@@ -138,9 +138,8 @@
               %b #{vote_in_words(@idea, current_citizen)},
             %h4 voit halutessasi vaihtaa kantaasi.
           - else
-            %h3 Kannatatko lakiehdotusta? 
-          %h4 Virallinen sähköinen kannatuksen ilmoittaminen ei ole vielä mahdollista Avoimen ministeriön palvelussa. Pyrimme valmistelemaan sen mahdollisimman pian. Tarkista aloitteen lopusta kuinka voit allekirjoittaa paperisen kannatusilmoituksen.
-          %h4 Sillä välin voit ilmoittaa epämuodollisen tukesi lakiehdotukselle. Ilmoitamme kaikille tukeneille kun myös sähköiset kannatusilmoitukset ovat mahdollisia.
+            %h3 Anna tukesi!
+          %h4 Saat sähköpostia kun voit allekirjoittaa sähköisesti.
           = link_to "Kyllä", vote_idea_path(@idea.id, vote: 1), class: "btn jaa-btn"
           = link_to "Ei", vote_idea_path(@idea.id, vote: 0), class: "btn ei-btn"
 


### PR DESCRIPTION
This commit changes the string as requested by Aleksi. I mentioned in the commit message that four automated tests failed, but because they fail on master as well, it's not a regression caused by my changes.
