### PR TITLE
Improved way to input article author

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 group :test do
   gem "capybara"
   gem "database_cleaner"
+  gem "rspec-rails-controller"
   gem "shoulda-matchers"
   gem "simplecov", :require => false
   gem "sqlite3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,8 @@ GEM
       activesupport (>= 3.0)
       railties (>= 3.0)
       rspec (~> 2.8.0)
+    rspec-rails-controller (0.1.2)
+      rspec-rails (>= 2.4.0)
     ruby-graphviz (0.9.21)
     rubyzip (0.9.5)
     sass (3.1.12)
@@ -249,6 +251,7 @@ DEPENDENCIES
   rb-fsevent
   redcarpet
   rspec-rails
+  rspec-rails-controller
   sass-rails (~> 3.1.5)
   shoulda-matchers
   simple_form

--- a/app/assets/stylesheets/admin/admin.css.scss
+++ b/app/assets/stylesheets/admin/admin.css.scss
@@ -4,3 +4,9 @@
  *= require admin/bootstrap-responsive
  *= require_directory .
  */
+
+#flash_error {
+    background: darken(red, 10%);
+    color: white;
+    padding: 0.5em;
+}

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -22,7 +22,7 @@ class Admin::ArticlesController < Admin::AdminController
   def create
     @article = build_article
     begin
-      @article.author = find_citizen_by_name(params[:author])
+      set_author
       @article.save
       respond_with @article, location: article_return_location
     rescue
@@ -40,7 +40,7 @@ class Admin::ArticlesController < Admin::AdminController
   def update
     @article = Article.find(params[:id])
     begin
-      @article.author = find_citizen_by_name(params[:author])
+      set_author
       flash[:notice] = I18n.t("articles.updated") if @article.update_attributes(params[:article])
       respond_with [:admin, @article]
     rescue
@@ -96,6 +96,14 @@ class Admin::ArticlesController < Admin::AdminController
     else
       Profile.where(:first_name => name_array[0],
         :last_name => name_array[1]).first.citizen
+    end
+  end
+  
+  def set_author
+    if params[:author].include? "@"
+      @article.author = Citizen.where(:email => params[:author]).first
+    else
+      @article.author = find_citizen_by_name(params[:author])
     end
   end
 end

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -86,7 +86,11 @@ class Admin::ArticlesController < Admin::AdminController
   end
   
   def find_citizen_by_name(name)
-    name_array = name.split
+    if name.include? ","
+      name_array = name.split(", ").reverse
+    else
+      name_array = name.split
+    end
     if name_array.length != 2
       raise "invalid name"
     else

--- a/app/views/admin/articles/_form.html.haml
+++ b/app/views/admin/articles/_form.html.haml
@@ -28,6 +28,10 @@
       - name = @article.author.profile.first_name + " " + @article.author.profile.last_name
     - else
       - name = ""
+
+    / Even though one can enter the name in reversed order with a comma
+    / (such as "Esimerkki, Erkki"), suggesting a certain form
+    / reduces confusion and makes filling the form faster.
     = text_field_tag(:author, name, :placeholder => "Erkki Esimerkki")
 
   %p

--- a/app/views/admin/articles/_form.html.haml
+++ b/app/views/admin/articles/_form.html.haml
@@ -1,8 +1,42 @@
-= simple_form_for @article, url: [:admin, @article] do |f|
-  = f.input :article_type, :collection => Article::VALID_ARTICLE_TYPES
-  = f.input :title
-  = f.input :ingress, as: :text
-  = f.input :body, as: :text
-  = f.association :author, collection: Citizen.unscoped.joins(:profile).order("profiles.last_name ASC, profiles.first_name ASC").all.collect{|c| ["#{c.profile.last_name}, #{c.profile.first_name}", c.id]}
-  = f.association :idea
-  = f.submit
+= form_tag [:admin, @article] do
+  - if @article.persisted?
+    = hidden_field_tag(:_method, "put")
+  %p
+    %label{:for => "article_article_type"}
+      = I18n.t("simple_form.labels.article_type")
+    = select(:article, :article_type, Article::VALID_ARTICLE_TYPES)
+
+  %p
+    %label{:for => "article_title"}
+      = I18n.t("simple_form.labels.title")
+    = text_field(:article, :title)
+
+  %p
+    %label{:for => "article_ingress"}
+      = I18n.t("simple_form.labels.ingress")
+    = text_area(:article, :ingress)
+
+  %p
+    %label{:for => "article_body"}
+      = I18n.t("simple_form.labels.body")
+    = text_area(:article, :body)
+
+  %p
+    %label{:for => "article_author"}
+      = I18n.t("simple_form.labels.author")
+    - if @article.author
+      - name = @article.author.profile.first_name + " " + @article.author.profile.last_name
+    - else
+      - name = ""
+    = text_field_tag(:author, name, :placeholder => "Erkki Esimerkki")
+
+  %p
+    %label{:for => "article_idea_id"}
+      = I18n.t("simple_form.labels.idea")
+    = collection_select(:article, :idea_id, Idea.all, :id, :title)
+
+  %p
+    - if @article.persisted?
+      = submit_tag(I18n.t("buttons.update") + " " + I18n.t("activerecord.models.article"))
+    - else
+      = submit_tag(I18n.t("buttons.create") + " " + I18n.t("activerecord.models.article"))

--- a/app/views/admin/articles/_form.html.haml
+++ b/app/views/admin/articles/_form.html.haml
@@ -22,7 +22,7 @@
     = text_area(:article, :body)
 
   %p
-    %label{:for => "article_author"}
+    %label{:for => "author"}
       = I18n.t("simple_form.labels.author")
     - if @article.author
       - name = @article.author.profile.first_name + " " + @article.author.profile.last_name

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -26,4 +26,6 @@
           %li= link_to "Muutosloki", admin_changelogs_path
           %li= link_to "Kirjaudu ulos", destroy_administrator_session_path, method: :delete
   .container-fluid{ style: "padding-top: 50px" }
+    - flash.each do |name, message|
+      %div{:id => ["flash", name]}= message
     = yield

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -43,6 +43,8 @@ fi:
           attributes:
             article_type:
               inclusion: "%{value} ei ole sallittu artikkelityyppi"
+        citizen:
+          not_found: "Henkilöä ei löytynyt"
   layout:
     your_profile: "Profiilisi"
     sign_out: "Kirjaudu ulos"
@@ -74,6 +76,8 @@ fi:
       edit_article: "Muokkaa artikkelia"
     edit:
       title: "Muokkaa artikkelia"
+  articles:
+    updated: "Artikkeli päivitetty"
   registrations:
     credentials:
       password_change_hint: "Jätä tämä tyhjäksi jos et halua vaihtaa salasanaasi"

--- a/config/locales/simple_form.fi.yml
+++ b/config/locales/simple_form.fi.yml
@@ -11,10 +11,12 @@ fi:
     error_notification:
       default_message: "Lomakkeessa oli virheitä, tarkistathan tiedot:"
     labels:
+      article_type: Artikkelin tyyppi
       title: Otsikko
       ingress: Johdanto
       body: Teksti
       author: Kirjoittaja
+      idea: Idea
     # Labels and hints examples
     # labels:
     #   password: 'Password'

--- a/config/locales/simple_form.fi.yml
+++ b/config/locales/simple_form.fi.yml
@@ -15,7 +15,7 @@ fi:
       title: Otsikko
       ingress: Johdanto
       body: Teksti
-      author: Kirjoittaja
+      author: Kirjoittaja (nimi tai sähköpostiosoite)
       idea: Idea
     # Labels and hints examples
     # labels:

--- a/spec/controllers/admin/articles_controller_spec.rb
+++ b/spec/controllers/admin/articles_controller_spec.rb
@@ -1,16 +1,150 @@
 require 'spec_helper'
 
+RSpec::Matchers.define :have_an_article_written_by do |citizen|
+  match do |idea|
+    for article in idea.articles
+      if article.author == citizen
+        return true
+      end
+    end
+    return false
+  end
+end
+
 describe Admin::ArticlesController do
+  let (:administrator) {
+    Factory(:administrator)
+  }
+  let (:unsaved_article) {
+    Factory.build(:article)
+  }
+  let (:article_hash) {{
+      :article_type => unsaved_article.article_type,
+      :title => unsaved_article.title,
+      :ingress => unsaved_article.ingress,
+      :body => unsaved_article.body,
+      :idea_id => unsaved_article.idea.id
+    }}
+  let (:citizen) {
+    Factory(:citizen)
+  }
 
   before :each do
-    @administrator = Factory(:administrator)
-    sign_in :administrator, @administrator
+    sign_in :administrator, administrator
   end
 
   describe "GET 'index'" do
     it "returns http success" do
       get 'index'
       response.should be_success
+    end
+  end
+  
+  post :create do
+    params {{:article => article_hash}}
+    before do
+      @article_count = Article.count
+      @request.env['HTTP_REFERER'] = new_article_path
+    end
+    context "with idea ID specified" do
+      context "with author name specified like 'John Smith'" do
+        params {{:article => article_hash,
+            :idea_id => unsaved_article.idea.id,
+            :author => citizen.profile.name}}
+        it "saves the article" do
+          action! do
+            its(:response) {should render_template(:create)}
+            Article.count.should == @article_count + 1
+            idea = unsaved_article.idea
+            idea.reload
+            idea.should have_an_article_written_by(citizen)
+          end
+        end
+      end
+      context "with author name specified like 'Smith, John'" do
+        params {{:article => article_hash,
+            :idea_id => unsaved_article.idea.id,
+            :author => citizen.profile.last_name + ", " +
+              citizen.profile.first_name}}
+        it "saves the article" do
+          action! do
+            idea = unsaved_article.idea
+            idea.reload
+            idea.should have_an_article_written_by(citizen)
+          end
+        end
+      end
+      context "with author email address specified instead of the name" do
+        params {{:article => article_hash,
+            :idea_id => unsaved_article.idea.id,
+            :author => citizen.email}}
+        it "saves the article" do
+          action! do
+            idea = unsaved_article.idea
+            idea.reload
+            idea.should have_an_article_written_by(citizen)
+          end
+        end
+      end
+      context "with author name missing" do
+        params {{:article => article_hash,
+            :idea_id => unsaved_article.idea.id
+          }}
+        it "does not save the article" do
+          action! do
+            its(:response) {should be_redirect}
+            its(:response) {should redirect_to(new_article_path)}
+            Article.count.should == @article_count
+            idea = unsaved_article.idea
+            idea.reload
+            idea.should_not have_an_article_written_by(nil)
+          end
+        end
+      end
+      context "with empty author name" do
+        params {{:article => article_hash,
+            :idea_id => unsaved_article.idea.id,
+            :author => ''
+          }}
+        it "does not save the article" do
+          action! do
+            Article.count.should == @article_count
+          end
+        end
+      end
+      context "with author name that is theoretically valid but absent in the database" do
+        params {{:article => article_hash,
+            :idea_id => unsaved_article.idea.id,
+            :author => "svub rgnvna"
+          }}
+        it "does not save the article" do
+          action! do
+            Article.count.should == @article_count
+          end
+        end
+      end
+      context "with author email address that is theoretically valid but absent in the database" do
+        params {{:article => article_hash,
+            :idea_id => unsaved_article.idea.id,
+            :author => "gvhj@vkvkkhv.com"
+          }}
+        it "does not save the article" do
+          action! do
+            Article.count.should == @article_count
+          end
+        end
+      end
+    end
+    context "with idea ID missing" do
+      params {{:article => article_hash,
+          :author => unsaved_article.author.profile.name}}
+      it "saves the article" do
+        action! do
+          idea = unsaved_article.idea
+          idea.reload
+          idea.should have_an_article_written_by(unsaved_article.author)
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,12 +12,14 @@ require 'rspec/autorun'
 require "capybara/rspec"
 require "database_cleaner"
 require 'controller_test_helper'
+require 'rspec/rails/controller'
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
 RSpec.configure do |config|
   config.mock_with :rspec
   config.use_transactional_fixtures = true
+  config.include RSpec::Rails::Controller::Macros, :type => :controller
   # config.infer_base_class_for_anonymous_controllers = false
 
   # config.treat_symbols_as_metadata_keys_with_true_values = true


### PR DESCRIPTION
The admin area contains a page where an admin can add an article to the database. He/she can set arbitrary citizen as the article author. Currently it is done with a dropdown. That approach has two problems:
- Creating the dropdown requires fetching all the citizens from the database (hopefully tens or hundreds of thousands in the future), which is horribly slow.
- It is also slow for the admin to find the right citizen from the dropdown. It would be faster to simply write his/her name.

These commits change the dropdown to a text field, which makes entering the author name much faster.
## Implementation notes
### Passing author name to the controller

It isn't possible to convert the name directly into a Citizen object. I have manually implemented the conversion in ArticlesController, but the problem is that when you try to save the object, ActiveRecord will complain that the **author** object is a String rather than a Citizen. The right way to fix that is to save author name outside the model object so that it doesn't cause problems when saving the object. Unfortunately, SimpleForm doesn't allow that. The options I had were
- dropping SimpleForm from the form partial (requires rewriting the partial from stratch)
- employing hacks such as replacing the **author** object within the controller

While I don't like rewriting files, I dislike hacks even more. Therefore I rewrote **views/admin/articles/_form.html.haml** from stratch.
### Flash messages

It's beyond me why flash messages aren't currently displayed in admin area. I made them visible. (Aleksi requested that the admin is informed when the citizen wasn't found, and my current implementation of that feature depends on flash.)
