### PR TITLE
Add styling for blockquotes in articles

### DIFF
--- a/app/assets/stylesheets/articles.css.scss
+++ b/app/assets/stylesheets/articles.css.scss
@@ -49,3 +49,9 @@
 .blog {
 	margin-bottom: 50px;
 }
+
+.idea_body blockquote {
+  margin-left: 20px;
+  font-size: 12px;
+  background-color: #f2f2f2;
+}


### PR DESCRIPTION
Currently blockquotes are styled only in comments, not in articles. As requested by Heli and Aleksi, this commit adds styling for blockquotes in articles, using exactly the same CSS as comments.
