### PR TITLE
Search improvements

### DIFF
--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -1,7 +1,6 @@
 
 $main-color: #473161;
 $turquoise: #29abe2;
-$serif: "Georgia";
 
 .search h2 {
   font-size: 19px;

--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -1,6 +1,7 @@
 
 $main-color: #473161;
 $turquoise: #29abe2;
+$serif: "Georgia";
 
 .search h2 {
   font-size: 19px;
@@ -23,4 +24,17 @@ $turquoise: #29abe2;
 
 .search-result-citizen {
   margin: 5px 0px 35px;
+}
+
+.search-result a {
+  color: #000;
+
+  .match {
+    font-weight: bold;
+  }
+}
+
+.result-count {
+  clear: both;
+  padding-top: 10px;
 }

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -190,6 +190,7 @@ class IdeasController < ApplicationController
     all_results = all_ideas + all_comments + all_articles + all_citizens
     
     @results = all_results.paginate(page: page, per_page: per_page)
+    @result_count = all_results.length
     
     @ideas = all_ideas & @results
     @comments = all_comments & @results

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -176,8 +176,8 @@ class IdeasController < ApplicationController
   end
 
   def search
-    per_page = 20
-    page = (params[:page] && params[:page].to_i) || 1
+    @per_page = 20
+    @page = (params[:page] && params[:page].to_i) || 1
     
     all_ideas = Idea.search_tank(params['searchterm']).select {
       |result| result.published?}
@@ -189,7 +189,7 @@ class IdeasController < ApplicationController
       |result| result.published?}
     all_results = all_ideas + all_comments + all_articles + all_citizens
     
-    @results = all_results.paginate(page: page, per_page: per_page)
+    @results = all_results.paginate(page: @page, per_page: @per_page)
     @result_count = all_results.length
     
     @ideas = all_ideas & @results

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,5 +1,7 @@
 #encoding: UTF-8
 
+require 'will_paginate/array'
+
 class IdeasController < ApplicationController
   before_filter :authenticate_citizen!, except: [ :index, :show, :search ]
   
@@ -174,10 +176,25 @@ class IdeasController < ApplicationController
   end
 
   def search
-    @ideas = Idea.search_tank(params['searchterm'])
-    @comments = Comment.search_tank(params['searchterm'])
-    @articles = Article.search_tank(params['searchterm'])
-    @citizens = Citizen.search_tank(params['searchterm'])
+    per_page = 20
+    page = (params[:page] && params[:page].to_i) || 1
+    
+    all_ideas = Idea.search_tank(params['searchterm']).select {
+      |result| result.published?}
+    all_comments = Comment.search_tank(params['searchterm']).select {
+      |result| result.published?}
+    all_articles = Article.search_tank(params['searchterm']).select {
+      |result| result.published?}
+    all_citizens = Citizen.search_tank(params['searchterm']).select {
+      |result| result.published?}
+    all_results = all_ideas + all_comments + all_articles + all_citizens
+    
+    @results = all_results.paginate(page: page, per_page: per_page)
+    
+    @ideas = all_ideas & @results
+    @comments = all_comments & @results
+    @articles = all_articles & @results
+    @citizens = all_citizens & @results
   end
 
   def vote_flow

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,7 +1,7 @@
 .comment.clearfix
   .avatar.grid_2
     %img{ src: comment.author.image, width: 50, height: 50 }
-  .grid_14
+  .grid_14{:id => "comment_#{comment.id}"}
     .info
       .grid_6
         %span.index

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -14,34 +14,39 @@
     tai 
     %i koira ja vero
     )
-  %h2 Ideat
-  - @ideas.each do |idea|
-    .search-result
-    =link_to idea.title, idea
-  %h2 Kommentit
-  - @comments.each do |comment|
-    .search-result
-    - case comment.commentable_type
-    - when "Idea"
-      =link_to comment.body, idea_path(comment.commentable_id)
-    - else
-      Tuntematon kommenttityyppi
-      =comment.commentable_type
-  %h2 Artikkelit
-  - @articles.each do |article|
-    .search-result
-    =link_to article.title, article
-  %h2 Kansalaiset
-  - @citizens.each do |citizen|
-    .search-result-citizen
-    %h3= citizen.name
-    - unless citizen.ideas.empty?
-      %h4 Ideat:
-      - citizen.ideas.each do |idea|
-        =link_to idea.title, idea
-    - unless citizen.comments.empty?
-      %h4 Kommentit:
-      - citizen.comments.each do |comment|
-        - case comment.commentable_type
-        - when "Idea"
-          =link_to comment.body, idea_path(comment.commentable_id)
+  - unless @ideas.empty?
+    %h2 Ideat
+    - @ideas.each do |idea|
+      .search-result
+      =link_to idea.title, idea
+  - unless @comments.empty?
+    %h2 Kommentit
+    - @comments.each do |comment|
+      .search-result
+      - case comment.commentable_type
+      - when "Idea"
+        =link_to comment.body, idea_path(comment.commentable_id)
+      - else
+        Tuntematon kommenttityyppi
+        =comment.commentable_type
+  -unless @articles.empty?
+    %h2 Artikkelit
+    - @articles.each do |article|
+      .search-result
+      =link_to article.title, article
+  -unless @citizens.empty?
+    %h2 Kansalaiset
+    - @citizens.each do |citizen|
+      .search-result-citizen
+      %h3= citizen.name
+      - unless citizen.ideas.empty?
+        %h4 Ideat:
+        - citizen.ideas.each do |idea|
+          =link_to idea.title, idea
+      - unless citizen.comments.empty?
+        %h4 Kommentit:
+        - citizen.comments.each do |comment|
+          - case comment.commentable_type
+          - when "Idea"
+            =link_to comment.body, idea_path(comment.commentable_id)
+= will_paginate @results

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -62,3 +62,10 @@
     = @result_count
     tulosta
   = will_paginate @results
+
+- KM.identify(current_citizen)
+:javascript
+  var results = document.getElementsByClassName("search-result")
+  for (var i=0;i<results.length;i++) {
+    _kmq.push(['trackClick', results[i], "search result " + i + " clicked"])
+  }

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -68,5 +68,5 @@
   var results = document.getElementsByClassName("search-result")
   for (var i=0;i<results.length;i++) {
     _kmq.push(['trackClick', results[i],
-      "search result " + (i + #{(@page-1) * @per_page}) + " clicked"])
+      "search result " + (i + 1 + #{(@page-1) * @per_page}) + " clicked"])
   }

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -25,7 +25,8 @@
       .search-result
       - case comment.commentable_type
       - when "Idea"
-        =link_to comment.body, idea_path(comment.commentable_id)
+        =link_to shorten(comment.body, 100, 10, "»"),
+          idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")
       - else
         Tuntematon kommenttityyppi
         =comment.commentable_type

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -67,5 +67,6 @@
 :javascript
   var results = document.getElementsByClassName("search-result")
   for (var i=0;i<results.length;i++) {
-    _kmq.push(['trackClick', results[i], "search result " + i + " clicked"])
+    _kmq.push(['trackClick', results[i],
+      "search result " + (i + #{(@page-1) * @per_page}) + " clicked"])
   }

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -18,36 +18,47 @@
     %h2 Ideat
     - @ideas.each do |idea|
       .search-result
-      =link_to idea.title, idea
+        %a{:href => idea_path(idea)}
+          != shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»")
   - unless @comments.empty?
     %h2 Kommentit
     - @comments.each do |comment|
       .search-result
-      - case comment.commentable_type
-      - when "Idea"
-        =link_to shorten(comment.body, 100, 10, "»"),
-          idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")
-      - else
-        Tuntematon kommenttityyppi
-        =comment.commentable_type
+        - case comment.commentable_type
+        - when "Idea"
+          %a{:href => idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")}
+            != shorten_and_highlight(comment.body, params['searchterm'], 100, "«", "»")
+        - else
+          Tuntematon kommenttityyppi
+          =comment.commentable_type
   -unless @articles.empty?
     %h2 Artikkelit
     - @articles.each do |article|
       .search-result
-      =link_to article.title, article
+        %a{:href => article_path(article)}
+          != shorten_and_highlight(article.title, params['searchterm'], 100, "«", "»")
   -unless @citizens.empty?
     %h2 Kansalaiset
     - @citizens.each do |citizen|
       .search-result-citizen
-      %h3= citizen.name
-      - unless citizen.ideas.empty?
-        %h4 Ideat:
-        - citizen.ideas.each do |idea|
-          =link_to idea.title, idea
-      - unless citizen.comments.empty?
-        %h4 Kommentit:
-        - citizen.comments.each do |comment|
-          - case comment.commentable_type
-          - when "Idea"
-            =link_to comment.body, idea_path(comment.commentable_id)
-= will_paginate @results
+        %h3!= shorten_and_highlight(citizen.name, params['searchterm'], 100, "«", "»")
+        - unless citizen.ideas.empty?
+          %h4 Ideat:
+          - citizen.ideas.each do |idea|
+            %a{:href => idea_path(idea)}
+              != shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»")
+        - unless citizen.comments.empty?
+          %h4 Kommentit:
+          - citizen.comments.each do |comment|
+            - case comment.commentable_type
+            - when "Idea"
+              %a{:href => idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")}
+                != shorten_and_highlight(comment.body, params['searchterm'], 100, "«", "»")
+
+.result-count
+  - if @result_count == 1
+    1 tulos
+  - else
+    = @result_count
+    tulosta
+  = will_paginate @results

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -88,6 +88,6 @@ fi:
     new:
       title: "Asiantuntijan ehdotus"
   will_paginate:
-    previous_label: "&laquo; Edelliset ideat"
-    next_label: "Seuraavat ideat &raquo;"
+    previous_label: "&laquo; Edelliset"
+    next_label: "Seuraavat &raquo;"
     page_gap: "..."

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -92,6 +92,6 @@ fi:
     new:
       title: "Asiantuntijan ehdotus"
   will_paginate:
-    previous_label: "&laquo; Edelliset ideat"
-    next_label: "Seuraavat ideat &raquo;"
+    previous_label: "&laquo; Edelliset"
+    next_label: "Seuraavat &raquo;"
     page_gap: "..."

--- a/spec/helpers/ideas_helper_spec.rb
+++ b/spec/helpers/ideas_helper_spec.rb
@@ -32,4 +32,78 @@ describe IdeasHelper do
       helper.vote_in_words(idea, citizen_1).should == "Kyllä"
     end
   end
+  
+  describe "#shorten_and_highlight" do
+    it "shortens and highlights given text" do
+      shortened_and_highlighted = helper.shorten_and_highlight(
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
+eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        "lorem ipsum",
+        50,
+        "«",
+        "»")
+      shortened_and_highlighted.length.should == 50 + " »".length
+      shortened_and_highlighted.should include(
+        '<span class="match">Lorem ipsum</span>')
+    end
+    
+    it "escapes HTML syntax" do
+      escaped = helper.shorten_and_highlight(
+        '<script type="text/javascript">alert("XSS")</script>',
+        "XSS",
+        100,
+        "«",
+        "»")
+      escaped.should_not include '<script type="text/javascript">'
+      escaped.should include '&lt;script type=&quot;text/javascript&quot;&gt;'
+    end
+    
+    it "does not highlight anything if the pattern doesn't match the text" do
+      shortened = helper.shorten_and_highlight(
+        "Lorem ipsum dolor sit amet", "äoughÄ", 100, "«", "»")
+      shortened.should_not include '<span class="match">'
+    end
+    
+    it "truncates the string at the beginning if the first match is too far" do
+      shortened_and_highlighted = helper.shorten_and_highlight(
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
+eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        "dolore magna aliqua",
+        50,
+        "«",
+        "»")
+      shortened_and_highlighted.should_not include "Lorem ipsum"
+      shortened_and_highlighted.should include(
+        '<span class="match">dolore magna aliqua</span>')
+      shortened_and_highlighted.should =~ /^« /
+    end
+    
+    it "does not highlight anything if the first match doesn't fit in the truncated string" do
+      shortened = helper.shorten_and_highlight(
+        "Lorem ipsum dolor sit amet", "lorem ipsum", 10, "«", "»")
+      shortened.should_not include '<span'
+    end
+    
+    it "inserts the ending sign" do
+      shortened_and_highlighted = helper.shorten_and_highlight(
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
+eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        "lorem ipsum",
+        50,
+        "«",
+        "»")
+      shortened_and_highlighted.should =~ / »$/
+    end
+    
+    it "does not insert the starting sign if the string hasn't been truncated at the beginning" do
+      shortened_and_highlighted = helper.shorten_and_highlight(
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
+eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        "lorem ipsum",
+        50,
+        "«",
+        "»")
+      shortened_and_highlighted.should_not include "«"
+    end
+  end
 end


### PR DESCRIPTION
These commits provide multiple improvements to searching:
- results are now paginated, shortened and highlighted
- results are easier to read because links are now black rather than blue
- comment links lead now straight to the comments instead of just the ideas
- result count has been added (most importantly, if there are no results, "0 tulosta" will be displayed)
- headings ("Ideat", "Artikkelit", "Kommentit" and "Kansalaiset") are no longer displayed if there aren't visible results under the heading (makes paginated search feel better)
- result clicks are now tracked (to help us improve result ordering)
- hidden articles, ideas, comments and citizens can't be displayed any longer

Technically my implementations are suboptimal. For example, highlighting is implemented by escaping result body, inserting HTML and finally outputting the string unescaped. It would be better to use Markdown, especially given that comments can contain Markdown syntax. Nevertheless, my implementations are working (for me) and Aleksi has said that he wants these improvements quickly into production.
