### PR TITLE
More search improvements

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -196,6 +196,19 @@ class IdeasController < ApplicationController
     @comments = all_comments & @results
     @articles = all_articles & @results
     @citizens = all_citizens & @results
+    
+    KM.identify(current_citizen)
+    track_clicks("idea", @ideas.length, @page)
+    track_clicks("comment", @comments.length, @page)
+    track_clicks("article", @articles.length, @page)
+    track_clicks("citizen", @citizens.length, @page)
+  end
+  
+  def track_clicks(type, count, page)
+    1.upto(count) do |i|
+      KM.track(type + "_" + i.to_s,
+        "search result #{type}_#{i} on page #{page} clicked")
+    end
   end
 
   def vote_flow

--- a/app/helpers/ideas_helper.rb
+++ b/app/helpers/ideas_helper.rb
@@ -41,8 +41,7 @@ module IdeasHelper
   
   def shorten_and_highlight(text, pattern, max_length, starting_sign, ending_sign)
     # highlighting is case insensitive, which requires a regular expression
-    regex = Regexp.new('(?<match>' + Regexp.escape(pattern) + ')',
-      Regexp::IGNORECASE)
+    regex = build_regex(pattern)
     escaped_text = CGI.escapeHTML(text)
     first_match_index = escaped_text.index(regex)
     if first_match_index.nil?
@@ -72,5 +71,27 @@ module IdeasHelper
       shortened_text.insert(0, starting_sign + " ")
     end
     return shortened_text
+  end
+  
+  def build_regex(pattern)
+    local_pattern = String.new(pattern)
+    # remove quotes
+    local_pattern.gsub!('"','')
+    # a term can be prefixed with a field name: remove such prefixes
+    index_of_last_colon = local_pattern.rindex(":")
+    if index_of_last_colon
+      pattern_substrings = local_pattern.split(":")
+      local_pattern = pattern_substrings[-1]
+    end
+    # a term can be suffixed with desired priority: remove such suffixes
+    index_of_first_caret = local_pattern.index("^")
+    if index_of_first_caret
+      pattern_substrings = local_pattern.split("^")
+      local_pattern = pattern_substrings[0]
+    end
+    # remove asterisks
+    local_pattern.gsub!("*","")
+    Regexp.new('(?<match>' + Regexp.escape(local_pattern) + ')',
+      Regexp::IGNORECASE)
   end
 end

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -16,40 +16,40 @@
     )
   - unless @ideas.empty?
     %h2 Ideat
-    - @ideas.each do |idea|
-      .search-result
-        %a{:href => idea_path(idea)}
-          != shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»")
+    - @ideas.length.times do |i|
+      .search-result{:id => "idea_#{i+1}"}
+        %a{:href => idea_path(@ideas[i])}
+          != shorten_and_highlight(@ideas[i].title, params['searchterm'], 100, "«", "»")
   - unless @comments.empty?
     %h2 Kommentit
-    - @comments.each do |comment|
-      .search-result
-        - case comment.commentable_type
+    - @comments.length.times do |i|
+      .search-result{:id => "comment_#{i+1}"}
+        - case @comments[i].commentable_type
         - when "Idea"
-          %a{:href => idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")}
-            != shorten_and_highlight(comment.body, params['searchterm'], 100, "«", "»")
+          %a{:href => idea_path(@comments[i].commentable_id, :anchor => "comment_#{@comments[i].id}")}
+            != shorten_and_highlight(@comments[i].body, params['searchterm'], 100, "«", "»")
         - else
           Tuntematon kommenttityyppi
-          =comment.commentable_type
+          =@comments[i].commentable_type
   -unless @articles.empty?
     %h2 Artikkelit
-    - @articles.each do |article|
-      .search-result
-        %a{:href => article_path(article)}
-          != shorten_and_highlight(article.title, params['searchterm'], 100, "«", "»")
+    - @articles.length.times do |i|
+      .search-result{:id => "article_#{i+1}"}
+        %a{:href => article_path(@articles[i])}
+          != shorten_and_highlight(@articles[i].title, params['searchterm'], 100, "«", "»")
   -unless @citizens.empty?
     %h2 Kansalaiset
-    - @citizens.each do |citizen|
-      .search-result-citizen
-        %h3!= shorten_and_highlight(citizen.name, params['searchterm'], 100, "«", "»")
-        - unless citizen.ideas.empty?
+    - @citizens.length.times do |i|
+      .search-result-citizen{:id => "citizen_#{i+1}"}
+        %h3!= shorten_and_highlight(@citizens[i].name, params['searchterm'], 100, "«", "»")
+        - unless @citizens[i].ideas.empty?
           %h4 Ideat:
-          - citizen.ideas.each do |idea|
+          - @citizens[i].ideas.each do |idea|
             %a{:href => idea_path(idea)}
               != shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»")
-        - unless citizen.comments.empty?
+        - unless @citizens[i].comments.empty?
           %h4 Kommentit:
-          - citizen.comments.each do |comment|
+          - @citizens[i].comments.each do |comment|
             - case comment.commentable_type
             - when "Idea"
               %a{:href => idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")}
@@ -62,11 +62,3 @@
     = @result_count
     tulosta
   = will_paginate @results
-
-- KM.identify(current_citizen)
-:javascript
-  var results = document.getElementsByClassName("search-result")
-  for (var i=0;i<results.length;i++) {
-    _kmq.push(['trackClick', results[i],
-      "search result " + (i + 1 + #{(@page-1) * @per_page}) + " clicked"])
-  }

--- a/spec/helpers/ideas_helper_spec.rb
+++ b/spec/helpers/ideas_helper_spec.rb
@@ -106,4 +106,36 @@ eiusmod tempor incididunt ut labore et dolore magna aliqua.",
       shortened_and_highlighted.should_not include "«"
     end
   end
+  
+  describe "#build_regex" do
+    it "builds regex from a string" do
+      regex = helper.build_regex("lorem ipsum")
+      regex.should == /(?<match>lorem\ ipsum)/i
+    end
+    
+    it "removes quotes" do
+      regex = helper.build_regex('"lorem ipsum"')
+      regex.should == /(?<match>lorem\ ipsum)/i
+    end
+    
+    it "removes field name prefixes" do
+      regex = helper.build_regex("body:lorem")
+      regex.should == /(?<match>lorem)/i
+    end
+    
+    it "removes priority suffixes" do
+      regex = helper.build_regex("lorem^2")
+      regex.should == /(?<match>lorem)/i
+    end
+    
+    it "removes asterisks" do
+      regex = helper.build_regex("lorem*")
+      regex.should == /(?<match>lorem)/i
+    end
+    
+    it "escapes regex syntax" do
+      regex = helper.build_regex("lorem|ipsum")
+      regex.should == /(?<match>lorem\|ipsum)/i
+    end
+  end
 end


### PR DESCRIPTION
The changes in the improve-search-looks branch were already merged even though they were (and still are) incomplete. Here are the improvements I have made since then.
- certain parts of queries are now stripped before highlighting, improving highlighting reliability
- result click tracking is now per-section, allowing us to see e.g. that the visitor clicked the first comment (as opposed to, say, the 14th result)
- moved click tracking code to controller side (as requested by Aleksi)
