### PR TITLE
Get rid of the [0, 0, false] spam when automated tests are run

### DIFF
--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -39,7 +39,6 @@ class Citizen < ActiveRecord::Base
   after_destroy :delete_tank_indexes
 
   def published_something?
-    p [ideas.count, comments.count, ideas.count > 0 || comments.count > 0 ]
     ideas.count > 0 || comments.count > 0 
 #    Idea.where("author_id = ?", author.id).count > 0 ||
 #      Article.where("author_id = ?", author.id).count > 0 ||


### PR DESCRIPTION
As I've mentioned in [issue 143](https://github.com/avoinministerio/avoinministerio/issues/143#issuecomment-6098495), something keeps outputting the text [0, 0, false] when automated tests are run. It's very annoying in my opinion.

Apparently Tanker attempts to index all citizens which are created during the tests and calls Citizen#published_something? to check if they should be indexed. Citizen#published_something?, on the other hand, prints some text to the standard output, causing the [0, 0, false] spam.

This commit fixes the issue by keeping Citizen#published_something? from printing anything.
