### PR TITLE
Basic specs for Signature Model

### DIFF
--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -1,5 +1,28 @@
 require 'spec_helper'
 
 describe Signature do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "Attributes" do
+    it { should be_accessible(:state) }
+    it { should be_accessible(:firstnames) }
+    it { should be_accessible(:lastname) }
+    it { should be_accessible(:birth_date) }
+    it { should be_accessible(:occupancy_county) }
+    it { should be_accessible(:vow) }
+    it { should be_accessible(:signing_date) }
+    it { should be_accessible(:stamp) }
+    it { should be_accessible(:started) }
+
+    describe "Validations" do
+    end
+  end
+
+  describe "Associations" do
+    it { should belong_to(:citizen) }
+    it { should belong_to(:idea) }
+
+    describe "Validations" do
+      it { should validate_presence_of(:citizen_id) }
+      it { should validate_presence_of(:idea_id) }
+    end
+  end
 end

--- a/spec/support/be_accessible_matcher.rb
+++ b/spec/support/be_accessible_matcher.rb
@@ -1,0 +1,10 @@
+# Review: http://stackoverflow.com/questions/9306392/how-to-test-attr-accessible-fields-in-rspec - jaakko
+
+RSpec::Matchers.define :be_accessible do |attribute|
+  match do |response|
+    response.class.accessible_attributes.include?(attribute)
+  end
+  description { "be accessible :#{attribute}" }
+  failure_message_for_should { ":#{attribute} should be accessible" }
+  failure_message_for_should_not { ":#{attribute} should not be accessible" }
+end


### PR DESCRIPTION
Added basic specs for  Signature model using shoulda-matcher's and added new matcher for testing accessible fields.
