### PR TITLE
Remove Markdown support from search

### DIFF
--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -28,8 +28,8 @@ $turquoise: #29abe2;
 .search-result a {
   color: #000;
 
-  p {
-    margin-bottom: 0;
+  .match {
+    font-weight: bold;
   }
 }
 

--- a/app/helpers/ideas_helper.rb
+++ b/app/helpers/ideas_helper.rb
@@ -46,7 +46,7 @@ module IdeasHelper
     first_match_index = escaped_text.index(regex)
     if first_match_index.nil?
       # the pattern doesn't match the text
-      return shorten(text, max_length, max_length/10, ending_sign)
+      return shorten(escaped_text, max_length, max_length/10, ending_sign)
     end
     highlighted_part_length = '<span class="match">'.length +
       pattern.length +
@@ -59,7 +59,7 @@ module IdeasHelper
       else
         # highlighted result won't fit in the truncated string,
         # so let's not highlight
-        return shorten(text, max_length, max_length/10, ending_sign)
+        return shorten(escaped_text, max_length, max_length/10, ending_sign)
       end
     else
       start_index = 0

--- a/app/helpers/ideas_helper.rb
+++ b/app/helpers/ideas_helper.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require "cgi"
+
 module IdeasHelper
   def idea_state_image(idea)
     filename = {
@@ -40,14 +42,15 @@ module IdeasHelper
   def shorten_and_highlight(text, pattern, max_length, starting_sign, ending_sign)
     # highlighting is case insensitive, which requires a regular expression
     regex = build_regex(pattern)
-    first_match_index = text.index(regex)
+    escaped_text = CGI.escapeHTML(text)
+    first_match_index = escaped_text.index(regex)
     if first_match_index.nil?
       # the pattern doesn't match the text
       return shorten(text, max_length, max_length/10, ending_sign)
     end
-    highlighted_part_length = "**".length +
+    highlighted_part_length = '<span class="match">'.length +
       pattern.length +
-      "**".length
+      '</span>'.length
     if first_match_index + highlighted_part_length > max_length
       # we need to truncate the string at the beginning
       if highlighted_part_length < max_length
@@ -61,7 +64,8 @@ module IdeasHelper
     else
       start_index = 0
     end
-    highlighted_text = text.gsub(regex, "**\\k<match>**")
+    highlighted_text = escaped_text.gsub(regex,
+      '<span class="match">\k<match></span>')
     shortened_text = highlighted_text[start_index, max_length] + " " + ending_sign
     if start_index > 0
       shortened_text.insert(0, starting_sign + " ")

--- a/app/views/ideas/search.html.haml
+++ b/app/views/ideas/search.html.haml
@@ -19,7 +19,7 @@
     - @ideas.each_with_index do |idea,i|
       .search-result{:id => "idea_#{i+1}"}
         %a{:href => idea_path(idea)}
-          = markdown(shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»"))
+          != shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»")
   - unless @comments.empty?
     %h2 Kommentit
     - @comments.each_with_index do |comment,i|
@@ -27,7 +27,7 @@
         - case comment.commentable_type
         - when "Idea"
           %a{:href => idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")}
-            = markdown(shorten_and_highlight(comment.body, params['searchterm'], 100, "«", "»"))
+            != shorten_and_highlight(comment.body, params['searchterm'], 100, "«", "»")
         - else
           Tuntematon kommenttityyppi
           =comment.commentable_type
@@ -36,25 +36,24 @@
     - @articles.each_with_index do |article,i|
       .search-result{:id => "article_#{i+1}"}
         %a{:href => article_path(article)}
-          = markdown(shorten_and_highlight(article.title, params['searchterm'], 100, "«", "»"))
+          != shorten_and_highlight(article.title, params['searchterm'], 100, "«", "»")
   -unless @citizens.empty?
     %h2 Kansalaiset
     - @citizens.each_with_index do |citizen,i|
       .search-result-citizen{:id => "citizen_#{i+1}"}
-        %h3
-          = markdown(shorten_and_highlight(citizen.name, params['searchterm'], 100, "«", "»"))
+        %h3!= shorten_and_highlight(citizen.name, params['searchterm'], 100, "«", "»")
         - unless citizen.ideas.empty?
           %h4 Ideat:
           - citizen.ideas.each do |idea|
             %a{:href => idea_path(idea)}
-              = markdown(shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»"))
+              != shorten_and_highlight(idea.title, params['searchterm'], 100, "«", "»")
         - unless citizen.comments.empty?
           %h4 Kommentit:
           - citizen.comments.each do |comment|
             - case comment.commentable_type
             - when "Idea"
               %a{:href => idea_path(comment.commentable_id, :anchor => "comment_#{comment.id}")}
-                = markdown(shorten_and_highlight(comment.body, params['searchterm'], 100, "«", "»"))
+                != shorten_and_highlight(comment.body, params['searchterm'], 100, "«", "»")
 
 .result-count
   - if @result_count == 1

--- a/spec/helpers/ideas_helper_spec.rb
+++ b/spec/helpers/ideas_helper_spec.rb
@@ -43,13 +43,25 @@ eiusmod tempor incididunt ut labore et dolore magna aliqua.",
         "«",
         "»")
       shortened_and_highlighted.length.should == 50 + " »".length
-      shortened_and_highlighted.should include "**Lorem ipsum**"
+      shortened_and_highlighted.should include(
+        '<span class="match">Lorem ipsum</span>')
+    end
+    
+    it "escapes HTML syntax" do
+      escaped = helper.shorten_and_highlight(
+        '<script type="text/javascript">alert("XSS")</script>',
+        "XSS",
+        100,
+        "«",
+        "»")
+      escaped.should_not include '<script type="text/javascript">'
+      escaped.should include '&lt;script type=&quot;text/javascript&quot;&gt;'
     end
     
     it "does not highlight anything if the pattern doesn't match the text" do
       shortened = helper.shorten_and_highlight(
         "Lorem ipsum dolor sit amet", "äoughÄ", 100, "«", "»")
-      shortened.should_not include "**"
+      shortened.should_not include '<span class="match">'
     end
     
     it "truncates the string at the beginning if the first match is too far" do
@@ -61,14 +73,15 @@ eiusmod tempor incididunt ut labore et dolore magna aliqua.",
         "«",
         "»")
       shortened_and_highlighted.should_not include "Lorem ipsum"
-      shortened_and_highlighted.should include "**dolore magna aliqua**"
+      shortened_and_highlighted.should include(
+        '<span class="match">dolore magna aliqua</span>')
       shortened_and_highlighted.should =~ /^« /
     end
     
     it "does not highlight anything if the first match doesn't fit in the truncated string" do
       shortened = helper.shorten_and_highlight(
         "Lorem ipsum dolor sit amet", "lorem ipsum", 10, "«", "»")
-      shortened.should_not include "**"
+      shortened.should_not include '<span'
     end
     
     it "inserts the ending sign" do


### PR DESCRIPTION
See http://am-staging.herokuapp.com/ideat/haku?utf8=%E2%9C%93&searchterm=markdown : a heading in a comment messes up a search result page.

These commits fix the issue by reverting back to the old highlighting implementation based on HTML rather than Markdown. Therefore Markdown in comments is no longer parsed and can't mess up search result pages. HTML in comments is naturally escaped in order to prevent XSS attacks.
