### PR TITLE
Add the libnotify gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,4 +72,5 @@ end
 
 group :linux_test do
   gem "therubyracer", :require => false
+  gem "libnotify", :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     json (1.7.3)
     json_pure (1.6.2)
     kgio (2.7.2)
+    libnotify (0.7.2)
+      ffi (~> 1.0.0)
     libv8 (3.3.10.4)
     mail (2.3.3)
       i18n (>= 0.4.0)
@@ -282,6 +284,7 @@ DEPENDENCIES
   hominid
   i18n_routing
   jquery-rails
+  libnotify
   newrelic_rpm
   nokogiri
   omniauth-facebook


### PR DESCRIPTION
This commit adds the libnotify gem into the linux_test group. Libnotify is the de-facto desktop notification library under GNU/Linux, and Guard is able to automatically make use of it.
