### PR TITLE
Move tests for SignaturesControllerHelpers into a separate file

### DIFF
--- a/spec/helpers/signatures_controller_helpers_spec.rb
+++ b/spec/helpers/signatures_controller_helpers_spec.rb
@@ -1,0 +1,20 @@
+describe SignaturesControllerHelpers do
+  describe "#guess_names" do
+    it "guess lastname from beginning TUPAS name 'lastname firstname'" do
+      helper.guess_names("Knuth Donald", "", "Knuth").should == ["Donald", "Knuth"]
+    end
+    it "guess lastname from end of TUPAS name 'lastname firstname'" do
+      helper.guess_names("Donald Knuth", "", "Knuth").should == ["Donald", "Knuth"]
+    end
+    it "guess lastname from beginning TUPAS name 'lastname firstname firstname'" do
+      helper.guess_names("Knuth Donald Ervin", "", "Knuth").should == ["Donald Ervin", "Knuth"]
+    end
+    it "guess lastname from end of TUPAS name 'lastname firstname firstname'" do
+      helper.guess_names("Donald Ervin Knuth", "", "Knuth").should == ["Donald Ervin", "Knuth"]
+    end
+    it "guess returns same if lastname doesn't match TUPAS name" do
+      helper.guess_names("Donald Ervin Knuth", "Donald", "Knuthi").should == ["Donald", "Knuthi"]
+      helper.guess_names("Knuth Donald Ervin", "Donald", "Knuthi").should == ["Donald", "Knuthi"]
+    end
+  end
+end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -56,25 +56,5 @@ describe Signature do
     it "assigns a randomized DateTime string as stamp" do
       @signature.stamp.should match(/\A[0-9]{14,20}\Z/)
     end
-  end
-
-  describe "#guess_names" do
-    let(:signature)  { SignaturesControllerHelpers }
-    it "guess lastname from beginning TUPAS name 'lastname firstname'" do
-      signature.guess_names("Knuth Donald", "", "Knuth").should == ["Donald", "Knuth"]
-    end
-    it "guess lastname from end of TUPAS name 'lastname firstname'" do
-      signature.guess_names("Donald Knuth", "", "Knuth").should == ["Donald", "Knuth"]
-    end
-    it "guess lastname from beginning TUPAS name 'lastname firstname firstname'" do
-      signature.guess_names("Knuth Donald Ervin", "", "Knuth").should == ["Donald Ervin", "Knuth"]
-    end
-    it "guess lastname from end of TUPAS name 'lastname firstname firstname'" do
-      signature.guess_names("Donald Ervin Knuth", "", "Knuth").should == ["Donald Ervin", "Knuth"]
-    end
-    it "guess returns same if lastname doesn't match TUPAS name" do
-      signature.guess_names("Donald Ervin Knuth", "Donald", "Knuthi").should == ["Donald", "Knuthi"]
-      signature.guess_names("Knuth Donald Ervin", "Donald", "Knuthi").should == ["Donald", "Knuthi"]
-    end
   end  
 end


### PR DESCRIPTION
This commit moves unit tests for SignaturesControllerHelpers into a separate file. There are two reasons for that.

First, by a RSpec convention you should not test multiple classes in one file.

Second, the tests were failing because they were in the wrong place. They pass after these changes.
