### PR TITLE
Fix radio button labels in signature terms approval

### DIFF
--- a/app/views/signatures/approval.html.haml
+++ b/app/views/signatures/approval.html.haml
@@ -16,10 +16,10 @@
               = label_tag :accept_non_eu, "Tietoni voi tallettaa EU:n ulkopuolella sijaitsevalle palvelimelle. Palvelun tietoturvallisuus on Viestintäviraston testaama ja hyväksymä"
             .radiobox
               = radio_button_tag :publicity, "Normal"
-              = label_tag :publicity, "Haluan, että nimeni tulee julkiseksi vasta jos aloite saavuttaa 50000 kannattajaa"
+              = label_tag :publicity_Normal, "Haluan, että nimeni tulee julkiseksi vasta jos aloite saavuttaa 50000 kannattajaa"
               %br
               = radio_button_tag :publicity, "Immediately"
-              = label_tag :publicity, "Nimeni voi julkistaa välittömästi"
+              = label_tag :publicity_Immediately, "Nimeni voi julkistaa välittömästi"
             .checkbox
               = check_box_tag :accept_science
               = label_tag :accept_science, "Sallin lisäkysymyksiä tieteellisissä tutkimuksissa. Tietojasi voidaan käyttää tieteessä henkilötietolain mukaisesti joka tapauksessa."


### PR DESCRIPTION
When a citizen wants to sign a law proposal online, he/she has to accept the terms of signing. Among other things, there is a pair of radio buttons which allow the citizen to specify if his/her name can be published before the proposal achieves the threshold of 50 000 signatures. (The law states that the names are public information after reaching the threshold.)

Currently the citizen can't select either radio button by clicking its label. These commits fix the issue. It was caused by slightly incorrect values of the "for" fields of the labels.
