### PR TITLE
Allow creating an article that doesn't belong to any idea

### DIFF
--- a/app/views/admin/articles/_form.html.haml
+++ b/app/views/admin/articles/_form.html.haml
@@ -37,7 +37,7 @@
   %p
     %label{:for => "article_idea_id"}
       = I18n.t("simple_form.labels.idea")
-    = collection_select(:article, :idea_id, Idea.all, :id, :title)
+    = collection_select(:article, :idea_id, Idea.all, :id, :title, :include_blank => true)
 
   %p
     - if @article.persisted?

--- a/spec/acceptance/admin/articles_spec.rb
+++ b/spec/acceptance/admin/articles_spec.rb
@@ -1,0 +1,54 @@
+#encoding: utf-8
+
+require "acceptance/acceptance_helper"
+
+feature "Articles" do
+  let (:idea) {
+    Factory :idea
+  }
+  describe "PUT /articles" do
+    before do
+      @author = create_citizen
+      create_logged_in_administrator
+      visit administrator_root_path
+      click_link "Artikkelit"
+      
+      current_path.should == admin_articles_path
+    end
+    it "creates a blog post" do      
+      click_link "Uusi artikkeli"
+      
+      current_path.should == new_admin_article_path
+      
+      select "blog", :from => "Artikkelin tyyppi"
+      fill_in "Otsikko", :with => "Ensimmäinen kansalaisaloite mennyt läpi"
+      fill_in "Johdanto", :with => "Ensimmäisen kerran kansalaisaloite on saavuttanut 50 000 allekirjoituksen rajan."
+      fill_in "Teksti", :with => "Läpi päässyt aloite ehdottaa automaattisten päänrapsuttimien tekemistä pakollisiksi."
+      fill_in "Kirjoittaja (nimi tai sähköpostiosoite)",
+        :with => @author.profile.name
+      select "", :from => "Idea"
+      click_button "Luo Artikkeli"
+      
+      current_path.should == admin_articles_path
+      page.should have_content "Ensimmäinen kansalaisaloite mennyt läpi"
+    end
+    it "creates a statement" do
+      idea
+      click_link "Uusi artikkeli"
+      
+      current_path.should == new_admin_article_path
+      
+      select "statement", :from => "Artikkelin tyyppi"
+      fill_in "Otsikko", :with => "Pakkoruotsi voidaan poistaa tavallisen lain säätämisjärjestyksessä"
+      fill_in "Johdanto", :with => "Pakkoruotsin poistaminen ei edellytä Suomen muuttamista yksikieliseksi maaksi."
+      fill_in "Teksti", :with => "Esimerkiksi Kanada on kaksikielinen maa, jossa ranska ei ole pakollinen oppiaine."
+      fill_in "Kirjoittaja (nimi tai sähköpostiosoite)",
+        :with => @author.profile.name
+      select idea.title, :from => "Idea"
+      click_button "Luo Artikkeli"
+      
+      current_path.should == admin_articles_path
+      page.should have_content "Pakkoruotsi voidaan poistaa tavallisen lain säätämisjärjestyksessä"
+    end
+  end
+end

--- a/spec/acceptance/support/helpers.rb
+++ b/spec/acceptance/support/helpers.rb
@@ -24,7 +24,7 @@ module HelperMethods
 
   def create_logged_in_administrator
     administrator = Factory(:administrator)
-    login(administrator)
+    login_as_administrator(administrator)
     administrator
   end
 


### PR DESCRIPTION
When I rewrote views/admin/articles/_form.html.haml from stratch, it became impossible to create an article that doesn't belong to any idea. I didn't know that it was **intentionally** allowed (most importantly to allow creating blog posts).

The first of these commits makes creating such articles possible again. In addition, because of Aleksi's request I added integration tests for creating articles. These tests make sure that the bug doesn't return without notice.
