### PR TITLE
Fix a Devise warning on startup

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -93,10 +93,6 @@ Devise.setup do |config|
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
 
-  # If true, uses the password salt as remember token. This should be turned
-  # to false if you are not using database authenticatable.
-  config.use_salt_as_remember_token = true
-
   # Options to be passed to the created cookie. For instance, you can set
   # :secure => true in order to force SSL only cookies.
   # config.cookie_options = {}


### PR DESCRIPTION
Currently Devise prints this warning to stdout (!) on startup:

```
[DEVISE] Devise.use_salt_as_remember_token is deprecated and has no effect. Please remove it.
```

This commit fixes the warning by doing what it says.
