### PR TITLE
Settings improvements

### DIFF
--- a/app/assets/javascripts/citizens.js.coffee
+++ b/app/assets/javascripts/citizens.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -35,6 +35,8 @@ header .login_actions a, header .idea_actions a {
 }
 header > .login_actions > div {
   float: right;
+  line-height: 25px;
+  text-align: right;
 }
 
 body > header > .top_row {

--- a/app/assets/stylesheets/citizens.css.scss
+++ b/app/assets/stylesheets/citizens.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Citizens controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/citizens_controller.rb
+++ b/app/controllers/citizens_controller.rb
@@ -1,0 +1,23 @@
+class CitizensController < ApplicationController
+  before_filter :authenticate_citizen!
+  before_filter :fetch_citizen
+  
+  def edit
+  end
+  
+  # based on https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-edit-their-password
+  def update
+    if @citizen.update_with_password(params[:citizen])
+      flash[:notice] = I18n.t("registrations.edit.password_updated")
+      sign_in @citizen, :bypass => true
+    end
+    render "edit"
+  end
+  
+  private
+  
+  def fetch_citizen
+    @citizen = current_citizen
+  end
+
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,6 +3,10 @@ class ProfilesController < ApplicationController
   before_filter :authenticate_citizen!
   before_filter :fetch_objects
   
+  def show
+    
+  end
+  
   def edit
     
   end
@@ -14,19 +18,9 @@ class ProfilesController < ApplicationController
     render "edit"
   end
   
-  # based on https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-edit-their-password
-  def update_password
-    if @citizen.update_with_password(params[:citizen])
-      flash[:notice] = I18n.t("registrations.edit.password_updated")
-      sign_in @citizen, :bypass => true
-    end
-    render "edit"
-  end
-  
   private
   
   def fetch_objects
-    @citizen = current_citizen
     @profile = current_citizen.profile
     @voted_ideas = Vote.by(current_citizen).map {|v| v.idea}
     @commented_ideas = current_citizen.comments.map do |comment|

--- a/app/helpers/citizens_helper.rb
+++ b/app/helpers/citizens_helper.rb
@@ -1,0 +1,2 @@
+module CitizensHelper
+end

--- a/app/views/citizens/edit.html.haml
+++ b/app/views/citizens/edit.html.haml
@@ -1,0 +1,16 @@
+%h2 Vaihda salasanasi
+= form_for @citizen do |f|
+  .input
+    = f.label :current_password
+    = f.password_field :current_password
+  
+  .input
+    = f.label :password
+    = f.text_field :password, :autocomplete => "off"
+  
+  .input
+    = f.label :password_confirmation
+    = f.text_field :password_confirmation
+  
+  .action_container
+    = f.submit "Vaihda salasana"

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -1,43 +1,28 @@
-- unless @voted_ideas.empty?
-  %h2{:style => "margin-top: 20px;"} Ideat, joita olet äänestänyt
-  
-  %ul
-    - @voted_ideas.each do |idea|
-      %li= link_to idea.title, idea_path(idea)
-
-- unless @commented_ideas.empty?
-  %h2{:style => "margin-top: 20px;"} Ideat, joita olet kommentoinut
-  
-  %ul
-    - @commented_ideas.each do |idea|
-      %li= link_to idea.title, idea_path(idea)
-
-%h2{:style => "margin-top: 20px;"} Asetukset
+%h2 Asetukset
 = simple_form_for @profile do |f|
-  = f.input :receive_newsletter
-  = f.input :receive_other_announcements
-  = f.input :receive_weekletter
   = f.input :first_names
   = f.input :first_name
   = f.input :last_name
   = f.input :image, :as => :url
+  = f.input :receive_newsletter
+  = f.input :receive_other_announcements
+  = f.input :receive_weekletter
   = f.input :accept_science
-  = f.input :accept_terms_of_use
-  = f.submit "Tallenna asetukset"
+  = f.input :accept_terms_of_use, :disabled => true
+  = f.submit "Tallenna asetukset", :id => "save-settings"
 
-%h2{:style => "margin-top: 20px;"} Vaihda salasanasi
-= form_for(@citizen, :url => {:action => "update_password"}) do |f|
-  .input
-    = f.label :current_password
-    = f.password_field :current_password
-  
-  .input
-    = f.label :password
-    = f.text_field :password, :autocomplete => "off"
-  
-  .input
-    = f.label :password_confirmation
-    = f.text_field :password_confirmation
-  
-  .action_container
-    = f.submit "Vaihda salasana"
+= link_to "Vaihda salasanasi", edit_citizen_path
+
+:javascript
+  $("#profile_accept_terms_of_use").change(function() {
+    if ($("#profile_accept_terms_of_use").attr("checked")) {
+      $("#save-settings").attr({"disabled": false})
+      $("#save-settings").removeClass("disabled")
+    }
+    else {
+      $("#save-settings").attr({"disabled": true})
+      $("#save-settings").addClass("disabled")
+    }})
+  $("#profile_accept_terms_of_use").attr({"disabled": false})
+  $("#profile_accept_terms_of_use").removeClass("disabled")
+  $("#profile_accept_terms_of_use").parent().removeClass("disabled")

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,0 +1,15 @@
+%h2 Ideat, joita olet äänestänyt
+- if @voted_ideas.empty?
+  Et ole äänestänyt yhtään ideaa.
+- else
+  %ul
+    - @voted_ideas.each do |idea|
+      %li= link_to idea.title, idea_path(idea)
+
+%h2 Ideat, joita olet kommentoinut
+- if @commented_ideas.empty?
+  Et ole kommentoinut yhtään ideaa.
+- else
+  %ul
+    - @commented_ideas.each do |idea|
+      %li= link_to idea.title, idea_path(idea)

--- a/app/views/shared/_login_actions.html.haml
+++ b/app/views/shared/_login_actions.html.haml
@@ -1,11 +1,14 @@
 .login_actions.top_row
   - if citizen_signed_in?
-    .grid_6
-      %img.avatar{ src: current_citizen.image, width: 25, height: 25 }
-      #{current_citizen.name}
-      = link_to "Profiili", edit_profile_path
+    .grid_8
+      = link_to "Profiili", profile_path
+      |
+      = link_to "Asetukset", edit_profile_path
       |
       = link_to "Kirjaudu ulos", destroy_citizen_session_path, method: :delete
+    .grid_4
+      %img.avatar{ src: current_citizen.image, width: 25, height: 25 }
+      #{current_citizen.name}
   - else
     .grid_3
       = link_to "Rekisteröidy", new_citizen_registration_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 AvoinMinisterio::Application.routes.draw do
 
-  resource :profile, :only => [:edit, :update] do
-    put "update_password", :on => :member
-  end
+  resource :profile, :except => [:new, :create, :destroy]  
+  resource :citizen, :only => [:edit, :update]
 
   match "/ideas/:id/vote/:vote"                       => "vote#vote",                   as: :vote_idea
 

--- a/db/migrate/20120704061305_enable_settings_by_default.rb
+++ b/db/migrate/20120704061305_enable_settings_by_default.rb
@@ -1,0 +1,40 @@
+class EnableSettingsByDefault < ActiveRecord::Migration
+  def up
+    change_column_default(:profiles, :receive_newsletter, true)
+    change_column_default(:profiles, :receive_other_announcements, true)
+    change_column_default(:profiles, :receive_weekletter, true)
+    change_column_default(:profiles, :accept_science, true)
+    change_column_default(:profiles, :accept_terms_of_use, true)
+    
+    Profile.all.each do |profile|
+      # We have to make the profile pass validation,
+      # or else it won't be saved
+      if profile.first_names.nil?
+        profile.first_names = profile.first_name
+      end
+      profile.receive_newsletter = true
+      profile.receive_other_announcements = true
+      profile.receive_weekletter = true
+      profile.accept_science = true
+      profile.accept_terms_of_use = true
+      profile.save
+    end
+  end
+
+  def down
+    change_column_default(:profiles, :receive_newsletter, nil)
+    change_column_default(:profiles, :receive_other_announcements, nil)
+    change_column_default(:profiles, :receive_weekletter, nil)
+    change_column_default(:profiles, :accept_science, nil)
+    change_column_default(:profiles, :accept_terms_of_use, nil)
+    
+    Profile.all.each do |profile|
+      profile.receive_newsletter = nil
+      profile.receive_other_announcements = nil
+      profile.receive_weekletter = nil
+      profile.accept_science = nil
+      profile.accept_terms_of_use = nil
+      profile.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120628071713) do
+ActiveRecord::Schema.define(:version => 20120704061305) do
 
   create_table "administrators", :force => true do |t|
     t.string   "email"
@@ -165,12 +165,12 @@ ActiveRecord::Schema.define(:version => 20120628071713) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "image"
-    t.boolean  "receive_newsletter"
-    t.boolean  "receive_other_announcements"
-    t.boolean  "receive_weekletter"
+    t.boolean  "receive_newsletter",          :default => true
+    t.boolean  "receive_other_announcements", :default => true
+    t.boolean  "receive_weekletter",          :default => true
     t.string   "first_names"
-    t.boolean  "accept_science"
-    t.boolean  "accept_terms_of_use"
+    t.boolean  "accept_science",              :default => true
+    t.boolean  "accept_terms_of_use",         :default => true
   end
 
   add_index "profiles", ["citizen_id"], :name => "index_profiles_on_citizen_id"

--- a/spec/controllers/citizens_controller_spec.rb
+++ b/spec/controllers/citizens_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe CitizensController do
+  let (:citizen) {
+    Factory :citizen
+  }
+
+  get :edit do
+    before do
+      sign_in citizen
+    end
+    action! do
+      it "assigns the citizen as @citizen" do
+        assigns(:citizen).should == citizen
+      end
+    end
+  end
+  
+  post :update do
+    pending "Need a way to check if the password has changed"
+  end
+
+end

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -8,16 +8,21 @@ describe ProfilesController do
   get :edit do
     before do
       sign_in citizen
-      @vote = Factory :vote, :citizen => citizen
-      @comment = Factory :comment, :author => citizen
     end
     action! do
       it "assigns the profile as @profile" do
         assigns(:profile).should == citizen.profile
       end
-      it "assigns the citizen as @citizen" do
-        assigns(:citizen).should == citizen
-      end
+    end
+  end
+  
+  get :show do
+    before do
+      sign_in citizen
+      @vote = Factory :vote, :citizen => citizen
+      @comment = Factory :comment, :author => citizen
+    end
+    action! do
       it "adds a voted idea into @voted_ideas" do
         assigns(:voted_ideas).should include @vote.idea
       end
@@ -25,10 +30,6 @@ describe ProfilesController do
         assigns(:commented_ideas).should include @comment.commentable
       end
     end
-  end
-  
-  post :update_password do
-    pending "Need a way to check if the password has been changed"
   end
   
   post :update do

--- a/spec/helpers/citizens_helper_spec.rb
+++ b/spec/helpers/citizens_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CitizensHelper. For example:
+#
+# describe CitizensHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       helper.concat_strings("this","that").should == "this that"
+#     end
+#   end
+# end
+describe CitizensHelper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/citizens/edit.html.haml_spec.rb
+++ b/spec/views/citizens/edit.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe "citizens/edit.html.haml" do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Here are the changes I have made since the profile-page branch was merged.
- split profile viewing, settings editing and password changing into separate pages
- all settings are enabled by default for both existing and new users
- when a citizen hasn't accepted the terms of use, the "save settings" button is disabled
- allocated more space for the div element that contains login actions ("profile", "settings" and "log out")
- moved checkboxes together in the settings page
