### PR TITLE
Use separate search indexes in development, staging and production

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,9 +1,9 @@
 class Article < ActiveRecord::Base
   include PublishingStateMachine
   include Changelogger
-  extend FriendlyId
-
+  include Concerns::Indexing
   include Tanker
+  extend FriendlyId
 
   VALID_ARTICLE_TYPES = %w(blog footer statement)
 
@@ -15,7 +15,7 @@ class Article < ActiveRecord::Base
   validates :article_type, inclusion: { in: VALID_ARTICLE_TYPES }
   validates :title, length: { minimum: 5 }
 
-  tankit 'BasicData' do
+  tankit index_name do
     conditions do
       published?
     end

--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -1,4 +1,7 @@
 class Citizen < ActiveRecord::Base
+  include Concerns::Indexing
+  include Tanker
+  
   # Include default devise modules. Others available are:
   # :token_authenticatable, :encryptable, :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -25,8 +28,7 @@ class Citizen < ActiveRecord::Base
     :image
   ].each { |attribute| delegate attribute, to: :profile }
 
-  include Tanker
-  tankit 'BasicData' do
+  tankit index_name do
     conditions do
       published_something?
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 class Comment < ActiveRecord::Base
   include PublishingStateMachine
   include Changelogger
-
+  include Concerns::Indexing
   include Tanker
 
   attr_accessible :body
@@ -17,7 +17,7 @@ class Comment < ActiveRecord::Base
   validates :commentable_id,    presence: true
   validates :commentable_type,  presence: true
 
-  tankit 'BasicData' do
+  tankit index_name do
     conditions do
       published?
     end

--- a/app/models/concerns/indexing.rb
+++ b/app/models/concerns/indexing.rb
@@ -1,0 +1,9 @@
+module Concerns::Indexing
+  extend ActiveSupport::Concern
+  
+  module ClassMethods
+    def index_name
+      ENV["Index_Name"] || "Development"
+    end
+  end
+end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -1,9 +1,9 @@
 class Idea < ActiveRecord::Base
   include PublishingStateMachine
   include Changelogger
-  extend FriendlyId
-
+  include Concerns::Indexing
   include Tanker
+  extend FriendlyId
 
   VALID_STATES = %w(idea draft proposal law)
 
@@ -33,7 +33,7 @@ class Idea < ActiveRecord::Base
   validates :body,  length: { minimum: 5, message: "Kuvaa ideasi hieman tarkemmin." }
   validates :state, inclusion: { in: VALID_STATES }
 
-  tankit 'BasicData' do
+  tankit index_name do
     conditions do
       published?
     end


### PR DESCRIPTION
Currently both the Searchify API URL and the index name are hardcoded into the application. As a result, all environments (development, staging and production) use the same index even though their databases are different.

This commit allows us to specify the index name with an environment variable called Index_Name. If the environment variable is not specified, an index called Development is used.

Note that this changes the default index name from BasicData to Development. As a result, search will not work in development environment before creating an index called Development.
