### PR TITLE
Ability to change email address

### DIFF
--- a/app/views/citizens/edit.html.haml
+++ b/app/views/citizens/edit.html.haml
@@ -1,8 +1,12 @@
-%h2 Vaihda salasanasi
+%h2 Vaihda sähköpostiosoite tai salasana
 = form_for @citizen do |f|
   .input
     = f.label :current_password
     = f.password_field :current_password
+
+  .input
+    = f.label :email
+    = f.email_field :email
   
   .input
     = f.label :password
@@ -13,4 +17,4 @@
     = f.text_field :password_confirmation
   
   .action_container
-    = f.submit "Vaihda salasana"
+    = f.submit "Tallenna muutokset"

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -11,7 +11,7 @@
   = f.input :accept_terms_of_use, :disabled => true
   = f.submit "Tallenna asetukset", :id => "save-settings"
 
-= link_to "Vaihda salasanasi", edit_citizen_path
+= link_to "Vaihda sähköpostiosoite tai salasana", edit_citizen_path
 
 :javascript
   $("#profile_accept_terms_of_use").change(function() {

--- a/spec/controllers/citizens_controller_spec.rb
+++ b/spec/controllers/citizens_controller_spec.rb
@@ -17,7 +17,44 @@ describe CitizensController do
   end
   
   post :update do
-    pending "Need a way to check if the password has changed"
+    context "with the right password" do
+      params {{:citizen => {
+            :current_password => citizen.password,
+            :password => "",
+            :password_confirmation => "",
+            :email => "citizen@example.com"
+          }}}
+      it "logged in" do
+        sign_in citizen
+        action! do
+          citizen.reload
+          citizen.email.should == "citizen@example.com"
+        end
+      end
+      it "as anonymous user" do
+        original_citizen = citizen.dup
+        action! do
+          citizen.reload
+          citizen.attributes.should == original_citizen.attributes
+        end
+      end
+    end
+    context "with a wrong password" do
+      params {{:citizen => {
+            :current_password => "wrong password",
+            :password => "",
+            :password_confirmation => "",
+            :email => "citizen@example.com"
+          }}}
+      it "logged in" do
+        original_citizen = citizen.dup
+        sign_in citizen
+        action! do
+          citizen.reload
+          citizen.attributes.should == original_citizen.attributes
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This commit allows a citizen to change his/her email address. Given how dangerous it is, the citizen must confirm that by entering his/her password.
