### PR TITLE
Fix RSpec coverage report generation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require "rubygems"
-require "simplecov"
 require "spork"
 
 # --- Instructions ---
@@ -35,6 +34,10 @@ Spork.prefork do
   # Loading more in this block will cause your tests to run faster. However,
   # if you change any configuration or code from libraries loaded here, you'll
   # need to restart spork for it take effect.
+  unless ENV['DRB']
+    require 'simplecov'
+    SimpleCov.start 'rails'
+  end
 
   ENV["RAILS_ENV"] ||= "test"
   require File.expand_path("../../config/environment", __FILE__)
@@ -89,6 +92,11 @@ Spork.prefork do
 end
 
 Spork.each_run do
+  if ENV['DRB']
+    require 'simplecov'
+    SimpleCov.start 'rails'
+  end
+  
   # REVIEW: https://github.com/sporkrb/spork/wiki/Spork.trap_method-Jujitsu - jaakko
   # This code will be run each time you run your specs.
   FactoryGirl.reload


### PR DESCRIPTION
When @jaakkos created the [Basic Guard setup with Rspec and Spork](https://github.com/avoinministerio/avoinministerio/pull/168), automated coverage reports stopped being generated. This commit fixes the issue as advised in https://github.com/colszowka/simplecov/issues/42#issuecomment-4440284 .
