### PR TITLE
Cope with indexing problems

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -31,8 +31,8 @@ class Article < ActiveRecord::Base
       "article"
     end
   end
-  after_save :update_tank_indexes
-  after_destroy :delete_tank_indexes
+  after_save Concerns::IndexingWrapper.new
+  after_destroy Concerns::IndexingWrapper.new
 
 
   def to_param

--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -42,8 +42,8 @@ class Citizen < ActiveRecord::Base
       "citizen"
     end
   end
-  after_save :update_tank_indexes
-  after_destroy :delete_tank_indexes
+  after_save Concerns::IndexingWrapper.new
+  after_destroy Concerns::IndexingWrapper.new
 
   def published_something?
     ideas.count > 0 || comments.count > 0 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,8 +31,8 @@ class Comment < ActiveRecord::Base
       "comment"
     end
   end
-  after_save :update_tank_indexes
-  after_destroy :delete_tank_indexes
+  after_save Concerns::IndexingWrapper.new
+  after_destroy Concerns::IndexingWrapper.new
 
   def prepare_for_unpublishing
     if self.body.blank?

--- a/app/models/concerns/indexing_wrapper.rb
+++ b/app/models/concerns/indexing_wrapper.rb
@@ -1,0 +1,17 @@
+class Concerns::IndexingWrapper
+  def after_save(record)
+    begin
+      record.send :update_tank_indexes
+    rescue IndexTank::HttpCodeException => e
+      Rails.logger.warn "Failed to index a document: #{e.message}"
+    end
+  end
+  
+  def after_destroy(record)
+    begin
+      record.send :delete_tank_indexes
+    rescue IndexTank::HttpCodeException => e
+      Rails.logger.warn "Failed to delete document from index: #{e.message}"
+    end
+  end
+end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -54,8 +54,8 @@ class Idea < ActiveRecord::Base
       state
     end
   end
-  after_save :update_tank_indexes
-  after_destroy :delete_tank_indexes
+  after_save Concerns::IndexingWrapper.new
+  after_destroy Concerns::IndexingWrapper.new
 
   def indexable?
     self.title.present?

--- a/spec/acceptance/signing/idea_signing_spec.rb
+++ b/spec/acceptance/signing/idea_signing_spec.rb
@@ -8,6 +8,13 @@ require 'webmock/rspec'
 feature "Idea signing" do
   let(:citizen_password) { '123456789' }
   let(:citizen_email) { 'citizen-kane@example.com'}
+  let(:idea) {
+    Factory :idea, state: "proposal", 
+                  collecting_started: true, collecting_ended: false, 
+                  collecting_start_date: today_date, collecting_end_date: today_date + 180, 
+                  additional_signatures_count: 0, additional_signatures_count_date: today_date, 
+                  target_count: 51500
+  }
 
   background do
     case 2
@@ -33,15 +40,10 @@ feature "Idea signing" do
 
   scenario "Succesful normal idea signing" do #, js: true do #, :driver => :webkit do
     # 1: Create idea and visit it's page to click on signing
-    create_idea({ state: "proposal", 
-                  collecting_started: true, collecting_ended: false, 
-                  collecting_start_date: today_date, collecting_end_date: today_date + 180, 
-                  additional_signatures_count: 0, additional_signatures_count_date: today_date, 
-                  target_count: 51500 })
-    visit idea_page(1)
-    should_be_on idea_page(1)
+    visit idea_page(idea.id)
+    should_be_on idea_page(idea.id)
     click_link "Allekirjoita kannatusilmoitus"
-    should_be_on signature_idea_introduction(1)
+    should_be_on signature_idea_introduction(idea.id)
 
     # 2: Click forward
     click_button "Siirry hyväksymään ehdot"
@@ -143,7 +145,15 @@ feature "Idea signing" do
     # 9: Thank you page again
     have_content "Kiitos kannatusilmoituksen allekirjoittamisesta"
   end
-
-
+  
+  context "individual steps" do
+    context "normal flow" do
+      scenario "1) go to signature introduction" do
+        visit idea_page(idea.id)
+        click_link "Allekirjoita kannatusilmoitus"
+        should_be_on signature_idea_introduction(idea.id)
+      end
+    end
+  end
 
 end

--- a/spec/acceptance/signing/idea_signing_spec.rb
+++ b/spec/acceptance/signing/idea_signing_spec.rb
@@ -8,13 +8,6 @@ require 'webmock/rspec'
 feature "Idea signing" do
   let(:citizen_password) { '123456789' }
   let(:citizen_email) { 'citizen-kane@example.com'}
-  let(:idea) {
-    Factory :idea, state: "proposal", 
-                  collecting_started: true, collecting_ended: false, 
-                  collecting_start_date: today_date, collecting_end_date: today_date + 180, 
-                  additional_signatures_count: 0, additional_signatures_count_date: today_date, 
-                  target_count: 51500
-  }
 
   background do
     case 2
@@ -40,10 +33,15 @@ feature "Idea signing" do
 
   scenario "Succesful normal idea signing" do #, js: true do #, :driver => :webkit do
     # 1: Create idea and visit it's page to click on signing
-    visit idea_page(idea.id)
-    should_be_on idea_page(idea.id)
+    create_idea({ state: "proposal", 
+                  collecting_started: true, collecting_ended: false, 
+                  collecting_start_date: today_date, collecting_end_date: today_date + 180, 
+                  additional_signatures_count: 0, additional_signatures_count_date: today_date, 
+                  target_count: 51500 })
+    visit idea_page(1)
+    should_be_on idea_page(1)
     click_link "Allekirjoita kannatusilmoitus"
-    should_be_on signature_idea_introduction(idea.id)
+    should_be_on signature_idea_introduction(1)
 
     # 2: Click forward
     click_button "Siirry hyväksymään ehdot"
@@ -145,15 +143,7 @@ feature "Idea signing" do
     # 9: Thank you page again
     have_content "Kiitos kannatusilmoituksen allekirjoittamisesta"
   end
-  
-  context "individual steps" do
-    context "normal flow" do
-      scenario "1) go to signature introduction" do
-        visit idea_page(idea.id)
-        click_link "Allekirjoita kannatusilmoitus"
-        should_be_on signature_idea_introduction(idea.id)
-      end
-    end
-  end
+
+
 
 end


### PR DESCRIPTION
Currently if Searchify can't index a new/changed document or delete a destroyed document from its index, the app crashes. It shouldn't, because
- crashing doesn't help: as the change has already occurred in the database, the index is already out of date
- it breaks "rake db:setup" (see [this gist](https://gist.github.com/3083301)), which creates a couple hundred documents at once (a crash in the middle terminates the whole operation)

The last of these commits makes the app cope with indexing problems. If indexing fails, it logs a warning but doesn't crash.
