### PR TITLE
More tests for signing and a couple of other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Run tests when RED-GREEN-REFACTOR:
 
         git checkout master
         git pull avoinministerio master
+        git push
         git checkout new-feature
         git rebase master
         # fix possible conflicts

--- a/app/views/ideas/_signature_info.html.haml
+++ b/app/views/ideas/_signature_info.html.haml
@@ -13,7 +13,7 @@
       - if current_citizen
         - twenty_mins = (1.0/(24*(60/20)))
         - if session["authenticated_at"] and DateTime.now < session["authenticated_at"]
-          raise "#{DateTime.now} is smaller than found session['authenticated_at'] #{session['authenticated_at']}"
+          - raise "#{DateTime.now} is smaller than found session['authenticated_at'] #{session['authenticated_at']}"
         - elsif check_shortcut_session_validity
           = link_to "Allekirjoita kannatusilmoitus ilman uutta tunnistautumista", signature_idea_shortcut_fillin_path(idea.id), class: "btn jaa-btn"
         - else

--- a/app/views/signatures/finalize_signing.html.haml
+++ b/app/views/signatures/finalize_signing.html.haml
@@ -18,7 +18,7 @@
             minuuttia tai kunnes kirjaudut ulos, joten voit allekirjoittaa aloitteita ilman, että sinun tarvitsee tunnistautua uudelleen.
         - else
           .text 
-            Tunnistautumisesi on ei ole enää voimassa, joten seuraavan kannatusilmoituksen allekirjoitukseen tunnistaudut uudelleen.
+            Tunnistautumisesi ei ole enää voimassa, joten seuraavan kannatusilmoituksen allekirjoitukseen tunnistaudut uudelleen.
 
       .other-initiatives
         %ul

--- a/spec/acceptance/signing/idea_signing_spec.rb
+++ b/spec/acceptance/signing/idea_signing_spec.rb
@@ -607,6 +607,14 @@ feature "Idea signing" do
       page.should have_content "Can't be signed"
       page.should_not have_button "Siirry hyväksymään ehdot"
     end
+    
+    scenario "the idea can't be signed and the citizen attempts to enter the approval page directly" do
+      idea_that_cannot_be_signed = Factory :idea
+      page.driver.post(signature_idea_approval_path(
+          idea_that_cannot_be_signed.id))
+      page.should have_content "Can't be signed"
+      page.should_not have_button "Hyväksy ehdot ja siirry tunnistautumaan"
+    end
   end
 
 end

--- a/spec/acceptance/signing/idea_signing_spec.rb
+++ b/spec/acceptance/signing/idea_signing_spec.rb
@@ -207,6 +207,7 @@ feature "Idea signing" do
       scenario "6) thank you page" do
         visit_signature_finalize_signing(idea.id, @citizen.id)
         page.should have_content "Kiitos kannatusilmoituksen allekirjoittamisesta"
+        page.should have_content "Tunnistautumisesi on nyt voimassa"
       end
       
       scenario "7) go to the shortcut fillin page" do
@@ -614,6 +615,20 @@ feature "Idea signing" do
           idea_that_cannot_be_signed.id))
       page.should have_content "Can't be signed"
       page.should_not have_button "Hyväksy ehdot ja siirry tunnistautumaan"
+    end
+    
+    scenario "authentication expires before signing" do
+      # probably signing should actually fail,
+      # but we're not testing for that now
+      visit_signature_returning(idea.id, @citizen.id)
+      select "Helsinki", from: "signature_occupancy_county"
+      check "Vow"
+      Timecop.travel(Time.now + 30.minutes)
+      click_button "Allekirjoita"
+      Timecop.return
+      
+      page.should have_content "Kiitos kannatusilmoituksen allekirjoittamisesta"
+      page.should have_content "Tunnistautumisesi ei ole enää voimassa"
     end
   end
 


### PR DESCRIPTION
Currently the rebasing instructions in the README don't have a "git push" command after "git pull avoinministerio master". Not running git push seems to cause git push at the end of rebasing to occasionally fail, which causes git to recommend running "git pull". Finally, git pull, especially without the --rebase switch, causes a lot of duplicate commits, conflicts and other problems.

The first of these commits fixes the issue by adding the "git push" command to the right place.

I also continue to add signing tests.
