### PR TITLE
Make broken lines visible in Opera

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -22,6 +22,7 @@ body > header, body > header.top_row_container > .container_24, .ideas_header.co
   border-width: 6px;
   -moz-border-image: url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
   -webkit-border-image: url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
+  -o-border-image: url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
   border-image: url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
   border-top: 0 none;
   border-left: 0 none;
@@ -160,6 +161,7 @@ input[type=submit] {
   border-width: 3px;
   -moz-border-image:url("/assets/border-dotted-vertical.png") 0 3 0 0 repeat;
   -webkit-border-image:url("/assets/border-dotted-vertical.png") 0 3 0 0 repeat;
+  -o-border-image:url("/assets/border-dotted-vertical.png") 0 3 0 0 repeat;
   border-image:url("/assets/border-dotted-vertical.png") 0 3 0 0 repeat;
   border-top: 0 none;
   border-left: 0 none;
@@ -232,6 +234,7 @@ input[type=submit] {
     border-width: 2px;
     -moz-border-image:url("/assets/border-dotted-horizontal.png") 0 0 2 0 repeat;
     -webkit-border-image:url("/assets/border-dotted-horizontal.png") 0 0 2 0 repeat;
+    -o-border-image:url("/assets/border-dotted-horizontal.png") 0 0 2 0 repeat;
     border-image:url("/assets/border-dotted-horizontal.png") 0 0 2 0 repeat;
     border-top: 0 none;
     border-left: 0 none;

--- a/app/assets/stylesheets/ideas.css.scss
+++ b/app/assets/stylesheets/ideas.css.scss
@@ -165,6 +165,7 @@ h1 {
   border-width: 6px;
   -moz-border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
   -webkit-border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
+  -o-border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
   border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
   border-top: none;
   border-left: 0 none;

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -14,6 +14,7 @@ $turquoise: #29abe2;
     //Refactor border to application.css 
     -moz-border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
     -webkit-border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
+    -o-border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
     border-image:url("/assets/border-double-dotted.png") 0 0 6 0 repeat;
     border-width: 6px;
     border-top: 0px none;

--- a/app/assets/stylesheets/vote.css.scss
+++ b/app/assets/stylesheets/vote.css.scss
@@ -5,7 +5,10 @@
 #votepie {
   -moz-border-radius: 10px;
   -webkit-border-radius: 10px;
+  border-radius: 10px;
   -webkit-box-shadow: 0 1px 3px #eee;
+  -moz-box-shadow: 0 1px 3px #eee;
+  box-shadow: 0 1px 3px #eee;
   margin: 0 auto;
   width: 270px;
   height: 200px;


### PR DESCRIPTION
I recently read [this blog post](http://blog.adrianroselli.com/2012/04/dont-blame-opera-blame-devs.html) and some related stuff and decided to fix our codebase regarding CSS vendor prefixes.

Here are the fixes. Eight lines of CSS. I used [CSS Lint](http://csslint.net/) to find the cases where we use only some of working vendor prefixes. -o- was missing in five places, unprefixed CSS in two places and -moz- in one place. -webkit- was always used.

The most visible difference after these changes is that broken lines are now also visible in Opera. It's a major change in the looks.
