### PR TITLE
Preload API tokens to ENV on application start.

### DIFF
--- a/config/api_keys/development.yml
+++ b/config/api_keys/development.yml
@@ -1,0 +1,16 @@
+SECRET_ElisaMobiilivarmenne: placeholder_key
+SECRET_Tapiolatesti: placeholder_key
+KISSMETRICS_API_KEY: placeholder_key
+MAILGUN_API_KEY: placeholder_key
+MAILGUN_SMTP_PASSWORD: placeholder_key
+SECRET_ElisaMobiilivarmennetesti: placeholder_key
+FACEBOOK_APP_ID: placeholder_key
+RAILS_SECRET_TOKEN: placeholder_key
+SECRET_Alandsbankentesti: placeholder_key
+FACEBOOK_APP_SECRET: placeholder_key
+NEW_RELIC_ID: placeholder_key
+NEW_RELIC_LICENSE_KEY: placeholder_key
+SECRET_Alandsbanken: placeholder_key
+Secret_Sampo: placeholder_key
+MAILGUN_SMTP_LOGIN: placeholder_key
+SECRET_Tapiola: placeholder_key

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,6 +1,10 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
+# preload various tokens to local ENV
+api_tokens = YAML.load(File.read(Rails.root.join('config', 'api_keys', "#{Rails.env}.yml"))) rescue {}
+api_tokens.each{ |key, val| ENV[key] = val }
+
 # Initialize the rails application
 AvoinMinisterio::Application.initialize!
 


### PR DESCRIPTION
Preload API tokens to ENV on application start. On production the yml file would be placed by chef.
