### PR TITLE
Security fixes for signing

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -339,6 +339,9 @@ class SignaturesController < ApplicationController
         @signature = finalize_signing_by_checking
         fill_in_acceptances(@signature)
       else
+        # @signature.idea is referenced in the view,
+        # so @signature mustn't be nil
+        @signature = Signature.where(state: 'authenticated').find(params[:id])
         @error = "Previously signed"
       end
       render :finalize_signing

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -1,4 +1,4 @@
-#encoding: UTF-8
+# #encoding: UTF-8
 
 require 'date'
 
@@ -10,10 +10,10 @@ class SignaturesController < ApplicationController
 
   before_filter :authenticate_citizen!
   before_filter :check_if_idea_can_be_signed, :except => [:returning,
-                                                          :cancelling,
-                                                          :rejecting,
-                                                          :finalize_signing,
-                                                          :shortcut_finalize_signing]
+    :cancelling,
+    :rejecting,
+    :finalize_signing,
+    :shortcut_finalize_signing]
 
   respond_to :html
 
@@ -31,69 +31,74 @@ class SignaturesController < ApplicationController
   end
 
   def sign
-    # ERROR: Check that user has not signed already
-    # TODO FIXME: check if user don't have any in-progress signatures
-    # ie. cover case when user does not type in the url (when Sign button is not shown)
+    # TODO FIXME: check if user don't have any in-progress signatures ie. cover
+    # case when user does not type in the url (when Sign button is not shown)
     @signature = Signature.create_with_citizen_and_idea(current_citizen, Idea.find(params[:id]))
 
-    # ERROR: check that there are enough acceptances
-    fill_in_acceptances(@signature)
-    @signature.idea_mac = idea_mac(@signature.idea)
-    @error = "Couldn't save signature" unless @signature.save!
+    if @signature
+      # ERROR: check that there are enough acceptances
+      fill_in_acceptances(@signature)
+      @signature.idea_mac = idea_mac(@signature.idea)
+      @error = "Couldn't save signature" unless @signature.save!
 
-    @services = [
-      { vers:       "0001",
-        rcvid:      "Elisa testi",
-        idtype:     "12",
-        name:       "Elisa Mobiilivarmenne testi",
-        url:        "https://mtupaspreprod.elisa.fi/tunnistus/signature.cmd",
-      },
-      { vers:       "0001",
-        rcvid:      "Avoinministerio",
-        idtype:     "12",
-        name:       "Elisa Mobiilivarmenne",
-        url:        "https://tunnistuspalvelu.elisa.fi/tunnistus/signature.cmd",
-      },
+      @services = [
+        { vers:       "0001",
+          rcvid:      "Elisa testi",
+          idtype:     "12",
+          name:       "Elisa Mobiilivarmenne testi",
+          url:        "https://mtupaspreprod.elisa.fi/tunnistus/signature.cmd",
+        },
+        { vers:       "0001",
+          rcvid:      "Avoinministerio",
+          idtype:     "12",
+          name:       "Elisa Mobiilivarmenne",
+          url:        "https://tunnistuspalvelu.elisa.fi/tunnistus/signature.cmd",
+        },
 
-      { vers:       "0002",
-        rcvid:      "AABTUPASID",
-        idtype:     "02",
-        name:       "Alandsbanken testi",
-        url:        "https://online.alandsbanken.fi/ebank/auth/initLogin.do",
-      },
-      { vers:       "0002",
-        rcvid:      "ELEKAMINNID",
-        idtype:     "02",
-        name:       "Alandsbanken",
-        url:        "https://online.alandsbanken.fi/ebank/auth/initLogin.do",
-      },
-      { vers:       "0002",
-        rcvid:      "KANNATUSTUPAS12",
-        idtype:     "02",
-        name:       "Tapiola testi",
-        url:        "https://pankki.tapiola.fi/service/identify",
-      },
-      { vers:       "0002",
-        rcvid:      "KANNATUSTUPAS12",
-        idtype:     "02",
-        name:       "Tapiola",
-        url:        "https://pankki.tapiola.fi/service/identify",
-      },
+        { vers:       "0002",
+          rcvid:      "AABTUPASID",
+          idtype:     "02",
+          name:       "Alandsbanken testi",
+          url:        "https://online.alandsbanken.fi/ebank/auth/initLogin.do",
+        },
+        { vers:       "0002",
+          rcvid:      "ELEKAMINNID",
+          idtype:     "02",
+          name:       "Alandsbanken",
+          url:        "https://online.alandsbanken.fi/ebank/auth/initLogin.do",
+        },
+        { vers:       "0002",
+          rcvid:      "KANNATUSTUPAS12",
+          idtype:     "02",
+          name:       "Tapiola testi",
+          url:        "https://pankki.tapiola.fi/service/identify",
+        },
+        { vers:       "0002",
+          rcvid:      "KANNATUSTUPAS12",
+          idtype:     "02",
+          name:       "Tapiola",
+          url:        "https://pankki.tapiola.fi/service/identify",
+        },
 
-      { vers:       "0003",
-        rcvid:      "024744039900",
-        idtype:     "02",
-        name:       "Sampo",
-        url:        "https://verkkopankki.sampopankki.fi/SP/tupaha/TupahaApp",
-      },
-    ]
+        { vers:       "0003",
+          rcvid:      "024744039900",
+          idtype:     "02",
+          name:       "Sampo",
+          url:        "https://verkkopankki.sampopankki.fi/SP/tupaha/TupahaApp",
+        },
+      ]
 
-    @services.each do |service|
-      set_defaults(service)
-      set_mac(service)
+      @services.each do |service|
+        set_defaults(service)
+        set_mac(service)
+      end
+      
+      respond_with @signature
+    
+    else
+      @error = "Aiemmin allekirjoitettu"
+      redirect_to idea_path(params[:id])
     end
-
-    respond_with @signature
   end
 
   def set_defaults(service)
@@ -128,7 +133,8 @@ class SignaturesController < ApplicationController
     Rails.logger.info "Using key #{secret_key}"
     secret = ENV[secret_key] || ""
 
-    # TODO: precalc the secret into environment variable, and remove this special handling
+    # TODO: precalc the secret into environment variable, and remove this
+    # special handling
     if service == "Alandsbanken" or service == "Tapiola"
       secret = secret_to_mac_string(secret)
       Rails.logger.info "Converting secret to #{secret}"
@@ -204,6 +210,8 @@ class SignaturesController < ApplicationController
         Rails.logger.info "repeated returning"
         @signature.update_attributes(state: "repeated_returning")
         @error = "Repeated returning"
+      elsif check_previously_signed(current_citizen, @signature.idea_id)
+        @error = "Aiemmin allekirjoitettu"
       else
         # all success!
         Rails.logger.info "All success, authentication ok, storing into session"
@@ -253,14 +261,15 @@ class SignaturesController < ApplicationController
   end
 
   def finalize_signing_by_checking
-#    @signature = current_citizen.signatures.where(state: 'authenticated').find(params[:id])
+    #    @signature = current_citizen.signatures.where(state: 'authenticated').find(params[:id])
     @signature = Signature.where(state: 'authenticated').find(params[:id])
     if @signature and @signature.citizen == current_citizen and @signature.state == "authenticated"   # TODO: and duration since last authentication less that threshold
       # validate input before storing
       if justNameCharacters(params["signature"]["firstnames"]) and 
-         justNameCharacters(params["signature"]["lastname"])   and 
-         municipalities.include? params["signature"]["occupancy_county"] and
-         params["signature"]["vow"] == "1"
+          justNameCharacters(params["signature"]["lastname"])   and 
+          municipalities.include? params["signature"]["occupancy_county"] and
+          params["signature"]["vow"] == "1"
+        unless check_previously_signed(current_citizen, @signature.idea_id)
 
         @signature.firstnames       = params["signature"]["firstnames"]
         @signature.lastname         = params["signature"]["lastname"]
@@ -280,6 +289,10 @@ class SignaturesController < ApplicationController
         ideas = Arel::Table.new(:ideas)
         proposals_not_in_already_signed = (ideas[:state].eq('proposal')).and(ideas[:id].not_in(already_signed))
         @initiatives = Idea.where(proposals_not_in_already_signed).order("vote_for_count DESC").limit(5).all
+        
+        else
+          @error = "Aiemmin allekirjoitettu"
+        end
       else
         @error = "Invalid parameters"
       end
@@ -301,7 +314,8 @@ class SignaturesController < ApplicationController
         @signature.accept_publicity     = @previous_signature.accept_publicity
         @signature.accept_science       = @previous_signature.accept_science
 
-        # Consider: would it be better to use @previous_signature instead of session to pick up all of these
+        # Consider: would it be better to use @previous_signature instead of
+        # session to pick up all of these
         @signature.signing_date         = today_date()
         @signature.birth_date           = session["authenticated_birth_date"]
         @signature.firstnames           = session["authenticated_firstnames"]
@@ -334,7 +348,12 @@ class SignaturesController < ApplicationController
   end
 
   def check_previously_signed(citizen, idea_id)
-    false
+    completed_signature = Signature.where(state: "signed", citizen_id: citizen.id, idea_id: idea_id).first
+    if completed_signature
+      true
+    else
+      false
+    end
   end
 
   def idea_mac(idea)

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -140,9 +140,8 @@ class SignaturesController < ApplicationController
       Rails.logger.info "Converting secret to #{secret}"
     end
 
-    unless secret
+    if secret == ""
       Rails.logger.error "No SECRET found for #{secret_key}"
-      secret = ""
     end
 
     secret

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -39,7 +39,10 @@ class SignaturesController < ApplicationController
       # ERROR: check that there are enough acceptances
       fill_in_acceptances(@signature)
       @signature.idea_mac = idea_mac(@signature.idea)
-      @error = "Couldn't save signature" unless @signature.save!
+      unless @signature.save
+        @error = "Couldn't save signature"
+        redirect_to signature_idea_introduction_path(params[:id]) and return
+      end
 
       @services = [
         { vers:       "0001",
@@ -322,7 +325,7 @@ class SignaturesController < ApplicationController
         @signature.occupancy_county     = session["authenticated_occupancy_county"]
         @signature.idea_mac             = idea_mac(@signature.idea)
         @signature.state                = "authenticated"
-        @error = "Couldn't save signature" unless @signature.save!
+        @error = "Couldn't save signature" unless @signature.save
       else
         @error = "Aiemmin allekirjoitettu"
       end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -11,20 +11,25 @@ class Signature < ActiveRecord::Base
   validates :idea_id, presence: true
 
   def self.create_with_citizen_and_idea(citizen, idea)
-    signature = new() do |s|
-      s.citizen = citizen
-      s.firstnames = citizen.first_names
-      s.lastname = citizen.last_name
-      s.idea = idea
-      s.idea_title = idea.title
-      s.idea_date = idea.updated_at
-      s.state = "initial"
-      s.stamp = DateTime.now.strftime("%Y%m%d%H%M%S") + rand(100000).to_s
-      s.started = Time.now
-      s.occupancy_county = ""
-    end
+    completed_signature = where(state: "signed", citizen_id: citizen.id, idea_id: idea.id).first
+    unless completed_signature
+      signature = new() do |s|
+        s.citizen = citizen
+        s.firstnames = citizen.first_names
+        s.lastname = citizen.last_name
+        s.idea = idea
+        s.idea_title = idea.title
+        s.idea_date = idea.updated_at
+        s.state = "initial"
+        s.stamp = DateTime.now.strftime("%Y%m%d%H%M%S") + rand(100000).to_s
+        s.started = Time.now
+        s.occupancy_county = ""
+      end
 
-    signature.save!
-    signature
+      signature.save!
+      signature
+    else
+      nil
+    end
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -1,5 +1,6 @@
 class Signature < ActiveRecord::Base
   VALID_STATES = %w(init query returned cancelled rejected)  # TODO: these are invalid at the moment, it's just initial, authenticated, and the last will be saved or error
+  VALID_PUBLICITY_OPTIONS = %w(Normal Immediately)
 
   attr_accessible :state, :firstnames, :lastname, :birth_date, :occupancy_county, :vow, :signing_date, :stamp, :started
   attr_accessible :accept_general, :accept_non_eu_server, :accept_publicity, :accept_science
@@ -9,6 +10,9 @@ class Signature < ActiveRecord::Base
 
   validates :citizen_id, presence: true
   validates :idea_id, presence: true
+  validates :accept_general, acceptance: {accept: true, allow_nil: false}
+  validates :accept_non_eu_server, acceptance: {accept: true, allow_nil: false}
+  validates :accept_publicity, inclusion: VALID_PUBLICITY_OPTIONS
 
   def self.create_with_citizen_and_idea(citizen, idea)
     completed_signature = where(state: "signed", citizen_id: citizen.id, idea_id: idea.id).first
@@ -26,7 +30,6 @@ class Signature < ActiveRecord::Base
         s.occupancy_county = ""
       end
 
-      signature.save!
       signature
     else
       nil

--- a/app/views/ideas/_signature_info.html.haml
+++ b/app/views/ideas/_signature_info.html.haml
@@ -3,21 +3,20 @@
   - ended     = idea.collecting_ended   || idea.collecting_end_date    < today_date
   - on_going  = started and (not ended)
 
-  - if current_citizen
-    - completed_signature = Signature.where(state: "signed", citizen_id: current_citizen.id, idea_id: idea.id).first
-    - if completed_signature
-      Olet jo allekirjoittanut kannatusilmoituksen onnistuneesti. Et voi allekirjoittaa sitä uudelleen, mutta nyt koska kyseessä on demo niin sallimme uusia ilmoituksia.
-
   - if on_going and idea.collecting_in_service
     .button
       - if current_citizen
-        - twenty_mins = (1.0/(24*(60/20)))
-        - if session["authenticated_at"] and DateTime.now < session["authenticated_at"]
-          - raise "#{DateTime.now} is smaller than found session['authenticated_at'] #{session['authenticated_at']}"
-        - elsif check_shortcut_session_validity
-          = link_to "Allekirjoita kannatusilmoitus ilman uutta tunnistautumista", signature_idea_shortcut_fillin_path(idea.id), class: "btn jaa-btn"
+        - completed_signature = Signature.where(state: "signed", citizen_id: current_citizen.id, idea_id: idea.id).first
+        - unless completed_signature
+          - twenty_mins = (1.0/(24*(60/20)))
+          - if session["authenticated_at"] and DateTime.now < session["authenticated_at"]
+            - raise "#{DateTime.now} is smaller than found session['authenticated_at'] #{session['authenticated_at']}"
+          - elsif check_shortcut_session_validity
+            = link_to "Allekirjoita kannatusilmoitus ilman uutta tunnistautumista", signature_idea_shortcut_fillin_path(idea.id), class: "btn jaa-btn"
+          - else
+            = link_to "Allekirjoita kannatusilmoitus", signature_idea_introduction_path(idea.id), class: "btn jaa-btn"
         - else
-          = link_to "Allekirjoita kannatusilmoitus", signature_idea_introduction_path(idea.id), class: "btn jaa-btn"
+          Olet jo allekirjoittanut kannatusilmoituksen onnistuneesti. Et voi allekirjoittaa sitä uudelleen.
       - else
         = link_to "Sisäänkirjaudu allekirjoittaaksesi kannatusilmoituksen", signature_idea_introduction_path(idea.id), class: "btn jaa-btn-disabled", disabled: true
 

--- a/app/views/signatures/cancelling.html.haml
+++ b/app/views/signatures/cancelling.html.haml
@@ -1,12 +1,6 @@
 .returning
-  - if not @error
-    %h1 Tunnistaminen ei onnistunut
-
-    Palaa 
+  .error
+    %h1 Tunnistaminen epäonnistui
+    Virhe
+    = @error
     =link_to "takaisin aloitteeseen", @signature.idea
-  - else
-    .error
-      %h1 Tunnistaminen epäonnistui
-      Virhe
-      = @error
-      =link_to "takaisin aloitteeseen", @signature.idea

--- a/app/views/signatures/rejecting.html.haml
+++ b/app/views/signatures/rejecting.html.haml
@@ -1,12 +1,6 @@
 .returning
-  - if not @error
-    %h1 Tunnistaminen ei onnistunut
-
-    Palaa 
+  .error
+    %h1 Tunnistaminen epäonnistui
+    Virhe
+    = @error
     =link_to "takaisin aloitteeseen", @signature.idea
-  - else
-    .error
-      %h1 Tunnistaminen epäonnistui
-      Virhe
-      = @error
-      =link_to "takaisin aloitteeseen", @signature.idea

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,8 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-AvoinMinisterio::Application.config.session_store :cookie_store, key: '_avoin_ministerio_session'
-
-# Use the database for sessions instead of the cookie-based default,
-# which shouldn't be used to store highly confidential information
-# (create the session table with "rails generate session_migration")
-# AvoinMinisterio::Application.config.session_store :active_record_store
+AvoinMinisterio::Application.config.session_store :active_record_store

--- a/db/migrate/20120727060642_add_sessions_table.rb
+++ b/db/migrate/20120727060642_add_sessions_table.rb
@@ -1,0 +1,16 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def up
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id
+    add_index :sessions, :updated_at
+  end
+
+  def down
+    drop_table :sessions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120716090326) do
+ActiveRecord::Schema.define(:version => 20120727060642) do
 
   create_table "administrators", :force => true do |t|
     t.string   "email"
@@ -176,6 +176,16 @@ ActiveRecord::Schema.define(:version => 20120716090326) do
   end
 
   add_index "profiles", ["citizen_id"], :name => "index_profiles_on_citizen_id"
+
+  create_table "sessions", :force => true do |t|
+    t.string   "session_id", :null => false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
+  add_index "sessions", ["updated_at"], :name => "index_sessions_on_updated_at"
 
   create_table "signatures", :force => true do |t|
     t.integer  "citizen_id"

--- a/spec/acceptance/signing/idea_signing_spec.rb
+++ b/spec/acceptance/signing/idea_signing_spec.rb
@@ -274,13 +274,7 @@ feature "Idea signing" do
         check "accept_non_eu_server"
         choose "publicity_Normal"
         click_button "Hyväksy ehdot ja siirry tunnistautumaan"
-        # FIXME: the first line is correct in a way that javascript _and_
-        # validation should prevent progressing to the next page. At the moment
-        # there is no validation so moving on is actually accepted. ie. fix
-        # validation, and then fix this test by removing comment from first
-        # line, and removing second line entirely
-        # current_path.should_not == signature_idea_fi_path(idea.id)
-        current_path.should eq(signature_idea_fi_path(idea.id))
+        should_be_on signature_idea_introduction_path(idea.id)
       end
       
       scenario "4) not logged in" do
@@ -345,6 +339,9 @@ feature "Idea signing" do
               # AFAIK, @citizen can't be passed to let, therefore let can't be
               # used
               @signature = Signature.create_with_citizen_and_idea(@citizen, idea)
+              @signature.accept_general = true
+              @signature.accept_non_eu_server = true
+              @signature.accept_publicity = "Normal"
             end
             scenario "existing signature has empty state" do
               @signature.state = ""
@@ -416,6 +413,9 @@ feature "Idea signing" do
               # AFAIK, @citizen can't be passed to let, therefore let can't be
               # used
               @signature = Signature.create_with_citizen_and_idea(@citizen, idea)
+              @signature.accept_general = true
+              @signature.accept_non_eu_server = true
+              @signature.accept_publicity = "Normal"
             end
             scenario "existing signature has empty state" do
               @signature.state = ""
@@ -653,11 +653,19 @@ feature "Idea signing" do
       background do
         # this time we send direct POST requests in order to bypass as many
         # security checks as possible
-        page.driver.post(signature_idea_path(idea.id))
+        page.driver.post(signature_idea_path(idea.id),
+                         {:accept_general => 1,
+                          :accept_non_eu_server => 1,
+                          :publicity => "Normal"
+                         })
         @first_signature = Signature.where(:idea_id => idea.id,
                                           :citizen_id => @citizen.id).last
         # reload the page, which creates another signature
-        page.driver.post(signature_idea_path(idea.id))
+        page.driver.post(signature_idea_path(idea.id),
+                         {:accept_general => 1,
+                          :accept_non_eu_server => 1,
+                          :publicity => "Normal"
+                         })
         @second_signature = Signature.where(:idea_id => idea.id,
                                            :citizen_id => @citizen.id).last
       end

--- a/spec/acceptance/signing/idea_signing_spec.rb
+++ b/spec/acceptance/signing/idea_signing_spec.rb
@@ -600,7 +600,7 @@ feature "Idea signing" do
     scenario "session['authenticated_at'] has an illegal value" do
       visit_signature_finalize_signing(idea.id, @citizen.id)
       Timecop.travel(Time.now - 1.minute)
-      expect {visit idea_page(idea.id)}.to raise_error
+      expect {visit idea_page(another_idea.id)}.to raise_error
       
       # BUG: If this test fails, the line below is not run and RSpec thinks that
       # the test took negative time. I'm not aware of any way to fix it.
@@ -661,8 +661,8 @@ feature "Idea signing" do
         # Try to complete the second signature
         service = "Capybaratesti"
         visit(capybara_test_return_url(@second_signature.id))
-        current_path.should_not ==
-          "/signatures/#{@second_signature.id}/returning/#{service}"
+        page.should have_content "Aiemmin allekirjoitettu"
+        page.should_not have_button "Allekirjoita"
       end
       scenario "go to the finalize signing page after signing for the first time" do
         # Authenticate for the second signature
@@ -679,8 +679,8 @@ feature "Idea signing" do
         visit_signature_finalize_signing_directly(@second_signature.id,
                                                   idea.title,
                                                   @citizen.profile)
-        current_path.should_not ==
-          "/signatures/#{@second_signature.id}/finalize_signing"
+        page.should have_content "Aiemmin allekirjoitettu"
+        page.should_not have_content "Kiitos kannatusilmoituksen allekirjoittamisesta"
       end
     end
     scenario "attempt to sign the proposal without authentication" do

--- a/spec/acceptance/support/helpers.rb
+++ b/spec/acceptance/support/helpers.rb
@@ -206,6 +206,25 @@ module HelperMethods
                       :vow => 1
                     }})
   end
+  
+  def visit_signature_shortcut_finalize_signing_directly(signature_id, idea_title, profile)
+    page.driver.put(signature_shortcut_finalize_signing_path(signature_id),
+                    {:params => {
+                      :signature => {
+                       :accept_general => 1,
+                       :accept_science => 1,
+                       :accept_non_eu_server => 1,
+                       :accept_publicity => "Normal",
+                       :idea_title => idea_title,
+                       :idea_date => today_date,
+                       :signing_date => today_date,
+                       :birth_date => Date.new(1970,1,1),
+                       :firstnames => profile.first_names,
+                       :lastname => profile.last_name,
+                       :occupancy_county => "Helsinki",
+                       :vow => 1
+                     }}})
+  end
 
 end
 

--- a/spec/acceptance/support/helpers.rb
+++ b/spec/acceptance/support/helpers.rb
@@ -203,7 +203,7 @@ module HelperMethods
                       :firstnames => profile.first_names,
                       :lastname => profile.last_name,
                       :occupancy_county => "Helsinki",
-                      :vow => true
+                      :vow => 1
                     }})
   end
 

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -22,12 +22,20 @@ describe SignaturesController do
     end
 
     it "assigns the newly created Signature as @signature" do
-      post :sign, :id => idea.id
+      post :sign,
+           :id => idea.id,
+           :accept_general => 1,
+           :accept_non_eu_server => 1,
+           :publicity => "Normal"
       assigns(:signature).should_not be nil
     end
 
     it "assigns available authentication services as @services" do
-      post :sign, :id => idea.id
+      post :sign,
+           :id => idea.id,
+           :accept_general => 1,
+           :accept_non_eu_server => 1,
+           :publicity => "Normal"
       assigns(:services).length.should be 7
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -79,5 +79,9 @@ FactoryGirl.define do
     association :citizen, factory: :citizen
     association :idea, factory: :idea
     state 'signed'
+    accept_general 1
+    accept_science 1
+    accept_non_eu_server 1
+    accept_publicity "Normal"
   end
 end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -34,8 +34,8 @@ describe Signature do
       @signature = Signature.create_with_citizen_and_idea(@citizen, @idea)
     end
 
-    it "creates a new Signature" do
-      @signature.new_record?.should be_false
+    it "builds a new Signature" do
+      @signature.new_record?.should be_true
     end
 
     it "assigns Citizen names" do


### PR DESCRIPTION
Yay! Pull request #200! :D

This commit fixes some security issues which, among other things, caused tests to fail.
- fixed: it was possible to sign a proposal multiple times*
- changed session_store to active_record_store, which stores sessions in a database instead of in cookies. It makes [session poisoning](http://en.wikipedia.org/wiki/Session_poisoning) attacks much harder. (Obviously, server-side bugs may still allow session poisoning.)
- fixed some bugs in tests

I also applied automatic reformatting to SignaturesController.

*I'm not sure if I actually fixed it fully. One test about it still fails. When I debugged the test, signing failed in the controller as expected, but the page that eventually got generated looked like signing had succeeded.
