### PR TITLE
Security hardening for signing

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -202,15 +202,15 @@ class SignaturesController < ApplicationController
       service_name = params[:servicename]
       if not valid_returning?(@signature, service_name)
         Rails.logger.info "Invalid return"
-        @signature.update_attributes(state: "invalid return")
+        @signature.state = "invalid return"
         @error = "Invalid return"
       elsif not within_timelimit?(@signature)
         Rails.logger.info "not within timelimit"
-        @signature.update_attributes(state: "too late")
+        @signature.state = "too late"
         @error = "Not within timelimit"
       elsif repeated_returning?(@signature)
         Rails.logger.info "repeated returning"
-        @signature.update_attributes(state: "repeated_returning")
+        @signature.state = "repeated_returning"
         @error = "Repeated returning"
       elsif check_previously_signed(current_citizen, @signature.idea_id)
         @error = "Aiemmin allekirjoitettu"
@@ -220,7 +220,8 @@ class SignaturesController < ApplicationController
         @error = nil
         birth_date = hetu_to_birth_date(params["B02K_CUSTID"])
         firstnames, lastname = guess_names(params["B02K_CUSTNAME"], @signature.firstnames, @signature.lastname)
-        @signature.update_attributes(state: "authenticated", signing_date: today_date(), birth_date: birth_date, firstnames: firstnames, lastname: lastname)
+        @signature.state = "authenticated"
+        @signature.update_attributes(signing_date: today_date(), birth_date: birth_date, firstnames: firstnames, lastname: lastname)
         session["authenticated_at"]         = DateTime.now
         session["authenticated_birth_date"] = birth_date
         session["authenticated_approvals"]  = @signature.id
@@ -237,7 +238,7 @@ class SignaturesController < ApplicationController
     else
       service_name = params[:servicename]
       Rails.logger.info "Cancelling"
-      @signature.update_attributes(state: "cancelled")
+      @signature.state = "cancelled"
       @error = "Cancelling authentication"
     end
     respond_with @signature
@@ -251,7 +252,7 @@ class SignaturesController < ApplicationController
     else
       service_name = params[:servicename]
       Rails.logger.info "Rejecting"
-      @signature.update_attributes(state: "rejected")
+      @signature.state = "rejected"
       @error = "Rejecting authentication"
     end
     respond_with @signature

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -2,7 +2,8 @@ class Signature < ActiveRecord::Base
   VALID_STATES = %w(init query returned cancelled rejected)  # TODO: these are invalid at the moment, it's just initial, authenticated, and the last will be saved or error
   VALID_PUBLICITY_OPTIONS = %w(Normal Immediately)
 
-  attr_accessible :state, :firstnames, :lastname, :birth_date, :occupancy_county, :vow, :signing_date, :stamp, :started
+  attr_protected :state
+  attr_accessible :firstnames, :lastname, :birth_date, :occupancy_county, :vow, :signing_date, :stamp, :started
   attr_accessible :accept_general, :accept_non_eu_server, :accept_publicity, :accept_science
 
   belongs_to  :citizen

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Signature do
   describe "Attributes" do
-    it { should be_accessible(:state) }
+    it { should_not be_accessible(:state) }
     it { should be_accessible(:firstnames) }
     it { should be_accessible(:lastname) }
     it { should be_accessible(:birth_date) }


### PR DESCRIPTION
This commit keeps Signature#state from being accessible for mass-assignment. Therefore any code that changes signature state must explicitly use the state= accessor and code like

```
@signature.update_attributes(params[:signature])
```

will not change the state of the signature. As a result, this commit makes it less likely that an attacker will find a way to sign a proposal without authentication.
