### PR TITLE
Sort ideas by creation time on the main page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -42,7 +42,7 @@ class PagesController < ApplicationController
     @proposal_and_drafts_counts = @proposals_counts.merge @draft_counts
 
     idea_count = 4
-    @ideas = Idea.published.where(state: 'idea').order("updated_at DESC").limit(idea_count).includes(:votes).all
+    @ideas = Idea.published.where(state: 'idea').order("created_at DESC").limit(idea_count).includes(:votes).all
     @idea_counts = {}
     @ideas.map do |idea|
       for_count      = idea.vote_counts[1] || 0


### PR DESCRIPTION
Currently ideas in the main page are sorted by the time of last update. It is not a good idea because it allows an idea to stay on the main page by spamming updates all the time. In addition, it looks like the updated_at timestamp is updated every time when the idea is voted and vote counters are updated, which absolutely shouldn't bring the idea to the main page.

This commit changes the ideas on the main page to be sorted by creation time, which doesn't change once the idea has been created.
