### PR TITLE
Fix KISSmetrics API key in development environment

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,7 +80,7 @@ class KM
   end
 
   def KM.api_key
-    ENV['KISSMETRICS_API_KEY'] || "690626c087893eef5f7307868202023d84f79acb"
+    ENV['KISSMETRICS_API_KEY']
   end
 
   def KM.js

--- a/config/api_keys/development.yml
+++ b/config/api_keys/development.yml
@@ -1,6 +1,6 @@
 SECRET_ElisaMobiilivarmenne: placeholder_key
 SECRET_Tapiolatesti: placeholder_key
-KISSMETRICS_API_KEY: placeholder_key
+KISSMETRICS_API_KEY: 690626c087893eef5f7307868202023d84f79acb
 MAILGUN_API_KEY: placeholder_key
 MAILGUN_SMTP_PASSWORD: placeholder_key
 SECRET_ElisaMobiilivarmennetesti: placeholder_key


### PR DESCRIPTION
Since the merge of Pull Request #198, the text "placeholder_key" has been used as the KISSmetrics API key in development environment. The result is that it is impossible to debug KISSmetrics code.

This commit fixes the issue by using the proper API key.
