### PR TITLE
Fix crash in tests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,7 +80,7 @@ class KM
   end
 
   def KM.api_key
-    ENV['KISSMETRICS_API_KEY']
+    ENV['KISSMETRICS_API_KEY'] || ""
   end
 
   def KM.js


### PR DESCRIPTION
My changes in Pull Request #206 caused a very frequent crash in tests, making dozens of tests to fail. The cause was that the KISSmetrics API key was nil in test environment, and in KM.identify the key was appended to the email address of the current citizen. Appending nil to a string causes a guaranteed crash.

This commit fixes the issue by restoring a piece of code that makes sure that the KISSmetrics API key can't be nil. However, the fallback API key is now an empty string instead of the right key. (The right key is already used in development environment thanks to Pull Request #206.)
