### PR TITLE
Stop using KISSmetrics in the Idea model

### DIFF
--- a/app/controllers/vote_controller.rb
+++ b/app/controllers/vote_controller.rb
@@ -3,6 +3,17 @@ class VoteController < ApplicationController
   before_filter :authenticate_citizen!
   
   def vote
+    KM.identify(current_citizen)
+    KM.push("record", "voted", {option: params[:vote], idea: @idea.id})
+    vote = @idea.votes.by(current_citizen).first
+    if vote
+      KM.push("record", "vote change of mind",
+              {option: params[:vote], idea: @idea.id})
+    else
+      KM.push("record", "first vote on idea",
+              {option: params[:vote], idea: @idea.id})
+    end
+    
     @idea.vote(current_citizen, params[:vote])
     flash[:notice] = flash_message
     redirect_to @idea

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -3,7 +3,6 @@ class Idea < ActiveRecord::Base
   include Changelogger
   include Concerns::Indexing
   include Tanker
-  include ApplicationHelper
   extend FriendlyId
 
   VALID_STATES = %w(idea draft proposal law)
@@ -77,17 +76,12 @@ class Idea < ActiveRecord::Base
 
   def vote(citizen, option)
     vote = votes.by(citizen).first
-    KM.identify(citizen)
     if vote
       update_vote_counts(option, vote.option)
       vote.update_attribute(:option, option) unless vote.option == option
-      KM.push("record", "voted",               {option: option, idea: self.id})
-      KM.push("record", "vote change of mind", {option: option, idea: self.id})
     else
       update_vote_counts(option, nil)
       votes.create(citizen: citizen, option: option)
-      KM.push("record", "voted",               {option: option, idea: self.id})
-      KM.push("record", "first vote on idea",  {option: option, idea: self.id})
     end
   end
   


### PR DESCRIPTION
Currently KISSmetrics receives information about voting when Idea#vote is called. Idea#vote is a wrong place for KISSmetrics code because, in general, model methods shouldn't send HTTP requests. In addition, currently Idea needs to include ApplicationHelper because the KM class is defined in ApplicationHelper. Finally, sending these HTTP requests greatly slows down "rake db:seed".

This commit moves KISSmetrics code to VoteController.
