### PR TITLE
Save the signature object in SignaturesController actions

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -227,6 +227,7 @@ class SignaturesController < ApplicationController
         session["authenticated_approvals"]  = @signature.id
       end
     end
+    @signature.save
     respond_with @signature
   end
 
@@ -239,6 +240,7 @@ class SignaturesController < ApplicationController
       service_name = params[:servicename]
       Rails.logger.info "Cancelling"
       @signature.state = "cancelled"
+      @signature.save
       @error = "Cancelling authentication"
     end
     respond_with @signature
@@ -253,6 +255,7 @@ class SignaturesController < ApplicationController
       service_name = params[:servicename]
       Rails.logger.info "Rejecting"
       @signature.state = "rejected"
+      @signature.save
       @error = "Rejecting authentication"
     end
     respond_with @signature


### PR DESCRIPTION
In Pull Request #202, I made Signature#state inaccessible for mass assignment. The point of the change was that you can no longer accidentally change signature state with the #update-attributes method. Therefore I edited SignaturesController actions so that they use the #state= accessor instead of #update-attributes.

However, there was one thing #update-attributes did but #state= doesn't: saving the signature. Now the object isn't saved in some actions, which may cause problems.

This commit fixes the issue. In addition, I extended automated tests so that they fail if the signature isn't saved.
