### PR TITLE
Restore ability to sign a proposal multiple times

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -16,24 +16,19 @@ class Signature < ActiveRecord::Base
   validates :accept_publicity, inclusion: VALID_PUBLICITY_OPTIONS
 
   def self.create_with_citizen_and_idea(citizen, idea)
-    completed_signature = where(state: "signed", citizen_id: citizen.id, idea_id: idea.id).first
-    unless completed_signature
-      signature = new() do |s|
-        s.citizen = citizen
-        s.firstnames = citizen.first_names
-        s.lastname = citizen.last_name
-        s.idea = idea
-        s.idea_title = idea.title
-        s.idea_date = idea.updated_at
-        s.state = "initial"
-        s.stamp = DateTime.now.strftime("%Y%m%d%H%M%S") + rand(100000).to_s
-        s.started = Time.now
-        s.occupancy_county = ""
-      end
-
-      signature
-    else
-      nil
+    signature = new() do |s|
+      s.citizen = citizen
+      s.firstnames = citizen.first_names
+      s.lastname = citizen.last_name
+      s.idea = idea
+      s.idea_title = idea.title
+      s.idea_date = idea.updated_at
+      s.state = "initial"
+      s.stamp = DateTime.now.strftime("%Y%m%d%H%M%S") + rand(100000).to_s
+      s.started = Time.now
+      s.occupancy_county = ""
     end
+
+    signature
   end
 end

--- a/app/views/ideas/_signature_info.html.haml
+++ b/app/views/ideas/_signature_info.html.haml
@@ -3,20 +3,21 @@
   - ended     = idea.collecting_ended   || idea.collecting_end_date    < today_date
   - on_going  = started and (not ended)
 
+  - if current_citizen
+    - completed_signature = Signature.where(state: "signed", citizen_id: current_citizen.id, idea_id: idea.id).first
+    - if completed_signature
+      Olet jo allekirjoittanut kannatusilmoituksen onnistuneesti. Et voi allekirjoittaa sitä uudelleen, mutta nyt koska kyseessä on demo niin sallimme uusia ilmoituksia.
+
   - if on_going and idea.collecting_in_service
     .button
       - if current_citizen
-        - completed_signature = Signature.where(state: "signed", citizen_id: current_citizen.id, idea_id: idea.id).first
-        - unless completed_signature
-          - twenty_mins = (1.0/(24*(60/20)))
-          - if session["authenticated_at"] and DateTime.now < session["authenticated_at"]
-            - raise "#{DateTime.now} is smaller than found session['authenticated_at'] #{session['authenticated_at']}"
-          - elsif check_shortcut_session_validity
-            = link_to "Allekirjoita kannatusilmoitus ilman uutta tunnistautumista", signature_idea_shortcut_fillin_path(idea.id), class: "btn jaa-btn"
-          - else
-            = link_to "Allekirjoita kannatusilmoitus", signature_idea_introduction_path(idea.id), class: "btn jaa-btn"
+        - twenty_mins = (1.0/(24*(60/20)))
+        - if session["authenticated_at"] and DateTime.now < session["authenticated_at"]
+          - raise "#{DateTime.now} is smaller than found session['authenticated_at'] #{session['authenticated_at']}"
+        - elsif check_shortcut_session_validity
+          = link_to "Allekirjoita kannatusilmoitus ilman uutta tunnistautumista", signature_idea_shortcut_fillin_path(idea.id), class: "btn jaa-btn"
         - else
-          Olet jo allekirjoittanut kannatusilmoituksen onnistuneesti. Et voi allekirjoittaa sitä uudelleen.
+          = link_to "Allekirjoita kannatusilmoitus", signature_idea_introduction_path(idea.id), class: "btn jaa-btn"
       - else
         = link_to "Sisäänkirjaudu allekirjoittaaksesi kannatusilmoituksen", signature_idea_introduction_path(idea.id), class: "btn jaa-btn-disabled", disabled: true
 


### PR DESCRIPTION
In Pull Request #200, I removed ability to sign a proposal multiple times. This commit reverts that change as requested by Aleksi. Note that it causes some tests to fail, and we must remember to revert this commit for production.
