### PR TITLE
Add ability to allow signing an idea multiple times with an environment variable

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -354,11 +354,15 @@ class SignaturesController < ApplicationController
   end
 
   def check_previously_signed(citizen, idea_id)
-    completed_signature = Signature.where(state: "signed", citizen_id: citizen.id, idea_id: idea_id).first
-    if completed_signature
-      true
-    else
+    if ENV["Allow_Signing_Multiple_Times"]
       false
+    else
+      completed_signature = Signature.where(state: "signed", citizen_id: citizen.id, idea_id: idea_id).first
+      if completed_signature
+        true
+      else
+        false
+      end
     end
   end
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -17,7 +17,7 @@ class Signature < ActiveRecord::Base
 
   def self.create_with_citizen_and_idea(citizen, idea)
     completed_signature = where(state: "signed", citizen_id: citizen.id, idea_id: idea.id).first
-    unless completed_signature
+    if !completed_signature || ENV["Allow_Signing_Multiple_Times"]
       signature = new() do |s|
         s.citizen = citizen
         s.firstnames = citizen.first_names

--- a/app/views/ideas/_signature_info.html.haml
+++ b/app/views/ideas/_signature_info.html.haml
@@ -3,11 +3,16 @@
   - ended     = idea.collecting_ended   || idea.collecting_end_date    < today_date
   - on_going  = started and (not ended)
 
+  - if ENV["Allow_Signing_Multiple_Times"] && current_citizen
+    - completed_signature = Signature.where(state: "signed", citizen_id: current_citizen.id, idea_id: idea.id).first
+    - if completed_signature
+      Olet jo allekirjoittanut kannatusilmoituksen onnistuneesti. Et voi allekirjoittaa sitä uudelleen, mutta nyt koska kyseessä on demo niin sallimme uusia ilmoituksia.
+  
   - if on_going and idea.collecting_in_service
     .button
       - if current_citizen
         - completed_signature = Signature.where(state: "signed", citizen_id: current_citizen.id, idea_id: idea.id).first
-        - unless completed_signature
+        - if !completed_signature || ENV["Allow_Signing_Multiple_Times"]
           - twenty_mins = (1.0/(24*(60/20)))
           - if session["authenticated_at"] and DateTime.now < session["authenticated_at"]
             - raise "#{DateTime.now} is smaller than found session['authenticated_at'] #{session['authenticated_at']}"


### PR DESCRIPTION
It has been hardcoded if a citizen is allowed to sign the same proposal multiple times. It is undesirable: disallowing it makes demonstrating the feature difficult, while allowing it is a big security risk (it might be left to allowed in production) and causes some automated tests to fail.

This commit adds ability to control that with a new environment variable, Allow_Signing_Multiple_Times. If the environment variable is not set, a citizen is allowed to sign the idea only once. If it is set, the citizen is allowed to sign the proposal as many times as he/she wants. _The value of the environment variable does not matter: even if its value is an empty string, "0" or "false", it means that the citizen is allowed to sign each proposal multiple times. The only way to disallow signing the idea multiple times is making sure that the environment variable is not set._
