### PR TITLE
Stop updating the updated_at timestamp in Idea#vote

### DIFF
--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -93,25 +93,23 @@ class Idea < ActiveRecord::Base
   
   def update_vote_counts(option, old_option)
     if old_option == nil
-      self.vote_count += 1
+      update_column("vote_count", self.vote_count + 1)
     elsif old_option == 0
       # decrement vote counter to keep the citizen from voting multiple times
-      self.vote_against_count -= 1
+      update_column("vote_against_count", self.vote_against_count - 1)
     else
       # decrement vote counter
-      self.vote_for_count -= 1
+      update_column("vote_for_count", self.vote_for_count - 1)
     end
     
     if option == 0
-      self.vote_against_count += 1
+      update_column("vote_against_count", self.vote_against_count + 1)
     else
-      self.vote_for_count += 1
+      update_column("vote_for_count", self.vote_for_count + 1)
     end
     
-    self.vote_proportion = self.vote_for_count.to_f / self.vote_count
-    self.vote_proportion_away_mid = (0.5 - self.vote_proportion).abs
-    
-    self.save
+    update_column("vote_proportion", self.vote_for_count.to_f / self.vote_count)
+    update_column("vote_proportion_away_mid", (0.5 - self.vote_proportion).abs)
   end
 
   def voted_by?(citizen)


### PR DESCRIPTION
Currently the updated_at timestamps of ideas change way too often. The cause was, as expected, that voting changes the values of vote counters and updates the updated_at timestamp.

This commit changes the Idea#vote method to use a low-level update_column method to change the values of vote counters. Update_column skips validations and callbacks, including Rails's internal callback that updates updated_at.
