### PR TITLE
Add instructions for creating a pre-commit hook that runs automated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,23 @@ If you want more information about the project, drop us an email to main@avoinmi
 
         cp config/database.yml.example config/database.yml
 
-6. Setup the database (create DB, load schema, load seed data)
+6. Create a pre-commit hook that runs automated tests before each commit and keeps you from committing if some tests fail. Create a file called `pre-commit` in the `.git/hooks` directory, and copy this content to it:
+
+        #!/usr/bin/env ruby
+        require File.expand_path('../../../config/application', __FILE__)
+        AvoinMinisterio::Application.load_tasks
+        Rake.application["spec"].reenable
+        Rake.application["spec"].invoke
+    
+    Also make the file executable:
+    
+        chmod +x .git/hooks/pre-commit
+    
+7. Setup the database (create DB, load schema, load seed data)
 
         bundle exec rake db:setup
 
-7. Start the app
+8. Start the app
 
         bundle exec rails s
 
@@ -78,13 +90,15 @@ Run tests when RED-GREEN-REFACTOR:
         git pull
         git rebase master
 
-5. Hack, commit and push your feature. Tests too :)
-
-        # Before adding and committing, it is a good practice to run tests
-        bundle exec rake spec
+5. Hack, commit and push your feature
 
         git add .
         git commit -m "Commit message"
+        git push
+    
+    If the commit fails due to failing tests but you need to commit your changes nevertheless, use the `--no-verify` switch.
+    
+        git commit -m "Commit message" --no-verify
         git push
 
 6. Pull and rebase the upstream repository


### PR DESCRIPTION
In Pull Request #168, @jaakkos set up Guard to allow us to notice easier when a change breaks something. I have Guard always running and it has often helped me.

But then I sent Pull Request #206 which broke dozens of tests. I had Guard running when I committed the changes, but Guard didn't complain about them at all. The reason is that, for performance reasons, Guard doesn't reload the environment when it changes, so Guard is not 100% reliable.

This commit extends the README by adding instructions to create a pre-commit hook that runs automated tests before each commit and keeps you from committing if some tests fail. I also adjusted existing instructions in the README. Finally, there are instructions in case you need to commit changes which cause tests to fail.
