### PR TITLE
Reduce database hits caused by voting

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -155,6 +155,7 @@ class IdeasController < ApplicationController
     @idea = Idea.new(params[:idea])
     @idea.author = current_citizen
     @idea.state  = "idea"
+    @idea.updated_content_at = DateTime.now
     if @idea.save
       flash[:notice] = I18n.t("idea.created")
       KM.identify(current_citizen)
@@ -170,6 +171,7 @@ class IdeasController < ApplicationController
   
   def update
     @idea = Idea.find(params[:id])
+    @idea.updated_content_at = DateTime.now
     if @idea.update_attributes(params[:idea])
       flash[:notice] = I18n.t("idea.updated") 
       KM.identify(current_citizen)

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -87,23 +87,25 @@ class Idea < ActiveRecord::Base
   
   def update_vote_counts(option, old_option)
     if old_option == nil
-      update_column("vote_count", self.vote_count + 1)
+      self.vote_count += 1
     elsif old_option == 0
       # decrement vote counter to keep the citizen from voting multiple times
-      update_column("vote_against_count", self.vote_against_count - 1)
+      self.vote_against_count -= 1
     else
       # decrement vote counter
-      update_column("vote_for_count", self.vote_for_count - 1)
+      self.vote_for_count -= 1
     end
     
     if option == 0
-      update_column("vote_against_count", self.vote_against_count + 1)
+      self.vote_against_count += 1
     else
-      update_column("vote_for_count", self.vote_for_count + 1)
+      self.vote_for_count += 1
     end
     
-    update_column("vote_proportion", self.vote_for_count.to_f / self.vote_count)
-    update_column("vote_proportion_away_mid", (0.5 - self.vote_proportion).abs)
+    self.vote_proportion = self.vote_for_count.to_f / self.vote_count
+    self.vote_proportion_away_mid = (0.5 - self.vote_proportion).abs
+    
+    self.save
   end
 
   def voted_by?(citizen)

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -20,7 +20,7 @@ class Idea < ActiveRecord::Base
                     :collecting_start_date, :collecting_end_date, 
                     :additional_signatures_count, :additional_signatures_count_date, 
                     :additional_collecting_service_urls,  # using !!! as a separator between multiple urls
-                    :target_count
+                    :target_count, :updated_content_at
 
   has_many :comments, as: :commentable
   has_many :votes

--- a/app/views/ideas/index.html.haml
+++ b/app/views/ideas/index.html.haml
@@ -62,7 +62,7 @@
           =state_localised(idea.state)
           \/
         %span.date
-          = finnishDate(idea.updated_at)
+          = finnishDate(idea.updated_content_at)
         - if idea.title.size > 0
           %h2= link_to idea.title, idea_path(idea, so: @sorting_order_code)
         - else

--- a/app/views/pages/_ideas.html.haml
+++ b/app/views/pages/_ideas.html.haml
@@ -6,7 +6,7 @@
         %span.type
           Idea/ 
         %span.date
-          = finnishDate(idea.updated_at)
+          = finnishDate(idea.updated_content_at)
         %h3=link_to shorten(idea.title + ": " + idea.summary, 200, 20, "»"), idea_path(idea), id: "ab_ideas_#{i}"
       .grid_16.statistics
         - for_, against, comments, total = @idea_counts[idea.id]

--- a/db/migrate/20120806062640_add_updated_content_at_to_ideas.rb
+++ b/db/migrate/20120806062640_add_updated_content_at_to_ideas.rb
@@ -1,0 +1,13 @@
+class AddUpdatedContentAtToIdeas < ActiveRecord::Migration
+  def up
+    add_column :ideas, :updated_content_at, :datetime
+    Idea.all.each do |idea|
+      idea.updated_content_at = idea.updated_at
+      idea.save
+    end
+  end
+  
+  def down
+    remove_column :ideas, :updated_content_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,20 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120727060642) do
+ActiveRecord::Schema.define(:version => 20120806062640) do
 
   create_table "administrators", :force => true do |t|
     t.string   "email"
-    t.string   "encrypted_password",     :default => "", :null => false
+    t.string   "encrypted_password",     :limit => 128, :default => "", :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          :default => 0
+    t.integer  "sign_in_count",                         :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.integer  "failed_attempts",        :default => 0
+    t.integer  "failed_attempts",                       :default => 0
     t.string   "unlock_token"
     t.datetime "locked_at"
     t.string   "password"
@@ -80,11 +80,11 @@ ActiveRecord::Schema.define(:version => 20120727060642) do
 
   create_table "citizens", :force => true do |t|
     t.string   "email"
-    t.string   "encrypted_password",     :default => "", :null => false
+    t.string   "encrypted_password",     :limit => 128, :default => "", :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          :default => 0
+    t.integer  "sign_in_count",                         :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -154,6 +154,8 @@ ActiveRecord::Schema.define(:version => 20120727060642) do
     t.integer  "target_count"
     t.boolean  "collecting_in_service"
     t.string   "additional_collecting_service_urls"
+    t.boolean  "anonymized"
+    t.datetime "updated_content_at"
   end
 
   add_index "ideas", ["author_id"], :name => "index_ideas_on_author_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -47,6 +47,7 @@ FactoryGirl.define do
     summary   "Hyvä idea"
     state     "idea"
     association :author, factory: :citizen
+    updated_content_at DateTime.now
   end
 
   factory :vote do


### PR DESCRIPTION
In Pull Request #213, I switched the Idea#vote method to use a low-level update_column method to change the values of vote counters. That kept Idea#vote from changing the updated_at timestamp which was updated way too often.

Unfortunately, update_column can only change one column at a time and saves the changes immediately to the database. Therefore updating the vote counters requires currently four database hits. It may be a bad performance problem in the future, especially given that voting is by far the most common action.

The first of these commits reverts the changes I made in Pull Request #213, reducing the number of database hits in Idea#vote from four to one (75 % reduction! :). The second one introduces a new attribute, Idea#updated_content_at, whose value tracks when the idea content (heading, summary or the body) was updated last time. It does not track vote counter changes. In addition, I swithed the idea lists to display updated_content_at instead of updated_at.
