### PR TITLE
Fix invalid vote counts

### DIFF
--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -96,7 +96,7 @@ class Idea < ActiveRecord::Base
       self.vote_for_count -= 1
     end
     
-    if option == 0
+    if option == "0"
       self.vote_against_count += 1
     else
       self.vote_for_count += 1

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -36,79 +36,79 @@ describe Idea do
 
   describe "#vote" do
     it "casts a vote on an idea" do
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.votes.count.should == 1
     end
 
     it "casts only one vote per idea per citizen" do
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.votes.by(citizen).count.should == 1
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.votes.by(citizen).count.should == 1
-      idea.vote(citizen, 0)
+      idea.vote(citizen, "0")
       idea.votes.by(citizen).count.should == 1
     end
     
     it "updates total vote count" do
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_count.should == 1
     end
     
     it "updates total vote count only once per citizen" do
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_count.should == 1
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_count.should == 1
-      idea.vote(citizen, 0)
+      idea.vote(citizen, "0")
       idea.vote_count.should == 1
     end
     
     it "increments vote_for_count" do
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_for_count.should == 1
     end
     
     it "increments vote_against_count" do
-      idea.vote(citizen, 0)
+      idea.vote(citizen, "0")
       idea.vote_against_count.should == 1
     end
     
     it "increments vote_for_count only once per citizen" do
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_for_count.should == 1
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_for_count.should == 1
     end
     
     it "decrements vote_for_count when citizen changes his/her mind" do
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_for_count.should == 1
-      idea.vote(citizen, 0)
+      idea.vote(citizen, "0")
       idea.vote_for_count.should == 0
-      idea.vote(citizen, 0)
+      idea.vote(citizen, "0")
       idea.vote_for_count.should == 0
     end
     
     it "decrements vote_against_count when citizen changes his/her mind" do
-      idea.vote(citizen, 0)
+      idea.vote(citizen, "0")
       idea.vote_against_count.should == 1
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_against_count.should == 0
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.vote_against_count.should == 0
     end
     
     it "calculates vote proportion" do
       another_citizen = Factory(:citizen)
-      idea.vote(citizen, 0)
-      idea.vote(another_citizen, 1)
+      idea.vote(citizen, "0")
+      idea.vote(another_citizen, "1")
       idea.vote_proportion.should be_within(0.001).of(1.0/2)
     end
     
     it "calculates vote_proportion_away_mid" do
       another_citizen = Factory(:citizen)
-      idea.vote(citizen, 0)
-      idea.vote(another_citizen, 1)
+      idea.vote(citizen, "0")
+      idea.vote(another_citizen, "1")
       idea.vote_proportion_away_mid.should be_within(0.001).of(0.0)
     end
   end
@@ -116,15 +116,15 @@ describe Idea do
   describe "#voted_by?" do
     it "tells whether citizen has voted for the idea or not" do
       idea.voted_by?(citizen).should be_false
-      idea.vote(citizen, 1)
+      idea.vote(citizen, "1")
       idea.voted_by?(citizen).should be_true
     end
   end
 
   describe "#vote_counts" do
     before do
-      5.times { Factory(:vote, option: 1, idea: idea) }
-      3.times { Factory(:vote, option: 0, idea: idea) }
+      5.times { Factory(:vote, option: "1", idea: idea) }
+      3.times { Factory(:vote, option: "0", idea: idea) }
     end
 
     it "returns the vote counts" do


### PR DESCRIPTION
It turned out that Pull Request #153 didn't completely fix invalid vote counts. As Aleksi guessed, the problem was caused by the fact that the option (either 0 [vote against] or 1 [vote for]) that the controller passed to Idea#vote was a string rather than an integer. When Idea#update_vote_counts compared the option to zero (integer), it never matched. Therefore every single vote incremented the votes_for count, even if the vote was against the idea. In addition, if the previous vote from the same citizen was against the idea, the votes_against_count was decremented. As a result, changing the vote continuously between "yes" and "no" kept incrementing votes_for_count and decrementing votes_against_count.

Aleksi's fix in Pull Request #217 was correct, but it also assumed that the old option (which the citizen previously chose) was a string as well. However, it's an integer. Therefore Aleksi's fix caused another, and a more severe, bug.

This is the proper fix that works according to my manual testing and unit tests. I also fixed the tests so that they pass a string rather than an integer to Idea#vote.

Finally, regarding existing vote counts I'd be on the safe side and re-run the script in Pull Request #153.
