### PR TITLE
Add a link for media into the footer

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -47,13 +47,16 @@
       = yield
   #footer_container
     %footer.container_24
-      %a.grid_4{ href: "/artikkelit/miten-palvelu-toimii" } Miten palvelu toimii?
-      %a.grid_4{ href: "/artikkelit/asiantuntijoille-ja-tutkijoille" } Asiantuntijoille
-      %a.grid_4{ href: "/artikkelit/yhteystiedot" } Yhteystiedot
-      %a.grid_4{ href: "/artikkelit/kayttoehdot" } Käyttöehdot
-      %a.grid_4{ href: asset_path('henkilorekisteriseloste.pdf') } Rekisteriseloste (pdf)
+      %a.grid_6{ href: "/artikkelit/miten-palvelu-toimii" } Miten palvelu toimii?
+      %a.grid_6{ href: "/artikkelit/asiantuntijoille-ja-tutkijoille" } Asiantuntijoille
+      %a.grid_6{ href: "/artikkelit/medialle" } Medialle
+      %a.grid_6{ href: "/artikkelit/yhteystiedot" } Yhteystiedot
+      %br
 
-      .grid_4
+      %a.grid_6{ href: "/artikkelit/kayttoehdot" } Käyttöehdot
+      %a.grid_6{ href: asset_path('henkilorekisteriseloste.pdf') } Rekisteriseloste (pdf)
+
+      .grid_6
         %div{:class => "addthis_toolbox addthis_default_style"}
           %a{:class => "addthis_button_preferred_1"}
           %a{:class => "addthis_button_preferred_2"}


### PR DESCRIPTION
As requested by Joonas, this commit extends the footer with a link that leads to the "For Media" article. It also splits the footer into two lines because it doesn't fit in one line anymore.
