### PR TITLE
Attempted fix for a crash

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,9 @@ module ApplicationHelper
   end
 
   def finnishDate(time)
+    if time.is_a? String
+      time = DateTime.parse(time)
+    end
     sprintf("%d.%d.%d", time.mday, time.month, time.year)
   end
 

--- a/db/migrate/20120806062640_add_updated_content_at_to_ideas.rb
+++ b/db/migrate/20120806062640_add_updated_content_at_to_ideas.rb
@@ -1,10 +1,13 @@
 class AddUpdatedContentAtToIdeas < ActiveRecord::Migration
   def up
     add_column :ideas, :updated_content_at, :datetime
+    
+    Idea.record_timestamps = false
     Idea.all.each do |idea|
       idea.updated_content_at = idea.updated_at
-      idea.save
+      idea.save(:validate => false)
     end
+    Idea.record_timestamps = true
   end
   
   def down


### PR DESCRIPTION
In Pull Request #216 I introduced the Idea#updated_content_at attribute. It caused problems in staging. First, Aleksi reported the following crash:

> jyrki, viimeisestä deployauksesta stagingille tulee virheilmoitusta: NoMethodError (undefined method `mday' for "2012-07-16 10:23:46.825083":String)

Second, the database migration failed to update some records, likely because they didn't pass validation. Finally, the database migration changed every single idea, which also updated their updated_at timestamps.

This commit attempts to fix all these issues.
- ApplicationHelper::finnishDate now detects if the passed time is a string and tries to parse it if necessary.
- The database migration now skips validation when saving the records.
- The database migration now disables timestamp recording before changing the ideas (and enables it afterwards).
