### PR TITLE
Payment abuse fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 # Ignore development databases
 avoin_ministerio_development
 avoin_ministerio_test
+
+# OS X
+.DS_Store

--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -99,9 +99,9 @@ class Citizen < ActiveRecord::Base
     c
   end
 
-  def deposit_money(amount, description)
-    mt = money_transactions.build(amount: amount, description: description)
-    raise "Can't save money transaction citizen_id=#{self.id} amount=#{amount} description=#{description}" unless mt.save
+  def deposit_money(amount, description, unique_identifier)
+    mt = money_transactions.build(amount: amount, description: description, unique_identifier: unique_identifier)
+    raise "Can't save money transaction citizen_id=#{self.id} amount=#{amount} description=#{description}. Errors: #{mt.errors}" unless mt.save
   end
 
   def saldo

--- a/app/models/citizen.rb
+++ b/app/models/citizen.rb
@@ -16,7 +16,7 @@ class Citizen < ActiveRecord::Base
   has_many :ideas, foreign_key: "author_id"
   has_many :comments, foreign_key: "author_id"
   has_many :idea_comments, through: :ideas
-  has_many :money_transactions, :class_name => 'MoneyTransactions'
+  has_many :money_transactions
   has_many :response_sets, foreign_key: "user_id"
 
   accepts_nested_attributes_for :profile

--- a/app/models/money_transaction.rb
+++ b/app/models/money_transaction.rb
@@ -1,4 +1,6 @@
 class MoneyTransaction < ActiveRecord::Base
-  attr_accessible :amount, :description
+  attr_accessible :amount, :description, :unique_identifier
   belongs_to :citizen
+
+  validates :unique_identifier, :uniqueness => true
 end

--- a/app/models/money_transaction.rb
+++ b/app/models/money_transaction.rb
@@ -1,4 +1,4 @@
-class MoneyTransactions < ActiveRecord::Base
+class MoneyTransaction < ActiveRecord::Base
   attr_accessible :amount, :description
   belongs_to :citizen
 end

--- a/app/views/signatures/service_selection.html.haml
+++ b/app/views/signatures/service_selection.html.haml
@@ -67,7 +67,7 @@
         - transaction_count = 4
         Viimeiset #{transaction_count} tapahtumaa ovat:
         /- self.money_transactions.order("created_at desc").limit(transaction_count).each do |mtx|
-        - MoneyTransactions.where("citizen_id = ?", current_citizen.id).order("created_at desc").limit(transaction_count).each do |mtx|
+        - MoneyTransaction.where("citizen_id = ?", current_citizen.id).order("created_at desc").limit(transaction_count).each do |mtx|
           .transaction
             %span.amount #{mtx.amount}€ 
             %span.description #{mtx.description}

--- a/db/migrate/20121009172141_add_unique_identifier_to_money_transaction.rb
+++ b/db/migrate/20121009172141_add_unique_identifier_to_money_transaction.rb
@@ -1,0 +1,7 @@
+class AddUniqueIdentifierToMoneyTransaction < ActiveRecord::Migration
+  def change
+    change_table :money_transactions do |table|
+      table.string :unique_identifier, length: 64, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120926213780) do
+ActiveRecord::Schema.define(:version => 20121009172141) do
 
   create_table "administrators", :force => true do |t|
     t.string   "email"
@@ -213,10 +213,11 @@ ActiveRecord::Schema.define(:version => 20120926213780) do
 
   create_table "money_transactions", :force => true do |t|
     t.integer  "citizen_id"
-    t.decimal  "amount",      :precision => 8, :scale => 2
+    t.decimal  "amount",            :precision => 8, :scale => 2
     t.string   "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "unique_identifier"
   end
 
   create_table "profiles", :force => true do |t|

--- a/spec/models/money_transaction_spec.rb
+++ b/spec/models/money_transaction_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe MoneyTransactions do
+describe MoneyTransaction do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
Require a unique identifier for each money transaction to prevent exploitation.
