### PR TITLE
seeds.rb was polluted by bogus characters now `rake db:setup` works fine

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,56 +1,43 @@
-#encoding: UTF-8
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
-
-
+# encoding: UTF-8
 require 'factory_girl_rails'
-
+puts "seeding data... this process can take 20-25 minutes"
 Administrator.find_or_create_by_email({
   email: "admin@avoinministerio.fi",
   password: "hallinta"
 })
-
 [
   { email: "joonas@pekkanen.com",
     password: "joonas1", password_confirmation: "joonas1", remember_me: true,
     profile_attributes: {first_names: "Joonas", first_name: "Joonas", last_name: "Pekkanen", name: "Joonas Pekkanen"}, },
-  
+
   { email: "arttu.tervo@gmail.com",
     password: "arttu1", password_confirmation: "arttu1", remember_me: true,
     profile_attributes: {first_names: "Arttu", first_name: "Arttu", last_name: "Tervo", name: "Arttu Tervo"}, },
-  
+
   { email: "aleksi.rossi@iki.fi",
     password: "aleksi1", password_confirmation: "aleksi1", remember_me: true,
     profile_attributes: {first_names: "Aleksi", first_name: "Aleksi", last_name: "Rossi", name: "Aleksi Rossi"}, },
-  
+
   { email: "hleinone@gmail.com",
     password: "hannu1", password_confirmation: "hannu1", remember_me: true,
     profile_attributes: {first_names: "Hannu", first_name: "Hannu", last_name: "Leinonen", name: "Hannu Leinonen"}, },
-  
+
   { email: "juha.yrjola@iki.fi",
     password: "juhay1", password_confirmation: "juhay1", remember_me: true,
     profile_attributes: {first_names: "Juha", first_name: "Juha", last_name: "Yrjölä", name: "Juha Yrjölä"}, },
-  
+
   { email: "lauri@kiskolabs.com",
     password: "lauri1", password_confirmation: "lauri1", remember_me: true,
     profile_attributes: {first_names: "Lauri", first_name: "Lauri", last_name: "Jutila", name: "Lauri Jutila"}, },
-  
+
   { email: "mikael.kopteff@gmail.com",
     password: "mikael1", password_confirmation: "mikael1", remember_me: true,
     profile_attributes: {first_names: "Mikael", first_name: "Mikael", last_name: "Kopteff", name: "Mikael Kopteff"}, },
 ].each { |citizen| Citizen.find_or_create_by_email(citizen) }
-
 @citizens = Citizen.all
-
 def random_citizen
   @citizens[rand(@citizens.size)]
 end
-
 joonas = Citizen.where(email: "joonas@pekkanen.com").first
 koiravero_body = <<EOS
 
@@ -103,7 +90,6 @@ _Voimaantulo_
 
 Tämä laki tulee voimaan 1. päivänä tammikuuta 2013.
 EOS
-
 opintotuki_body = <<EOS
 
 Yleisperustelut
@@ -202,7 +188,6 @@ Tämä laki tulee voimaan päivänä kuuta 20__.
 
 Ennen lain voimaantuloa voidaan ryhtyä lain toimeenpanon edellyttämiin toimiin.
 EOS
-
 [
   {
     title: "Koiraverolain kumoaminen",
@@ -237,7 +222,6 @@ EOS
     body: "Suuremmat rangaistukset olisivat linjakkaampia!",
     state: "idea", author: random_citizen},
 ].each { |idea| i = Idea.create(idea); i.state = idea[:state]; i.author = idea[:author]; i.save! }
-
 20.times do |i|
   idea = Idea.create(
     { title: "Esimerkki-idea #{i}", 
@@ -250,7 +234,6 @@ EOS
   idea.author = random_citizen
   idea.save!
 end
-
 voters = (0..100).map do |i|
   Citizen.find_or_create_by_email(
       email: "voter#{i}@voter.com",
@@ -258,20 +241,16 @@ voters = (0..100).map do |i|
       profile_attributes: {first_names: "Clueless Voter", first_name: "Voter", last_name: "#{i}", name: "Voter #{i}"}
     )
 end
-
 Idea.all.each do |idea|
   rand(5).times { Factory(:comment, commentable: idea, author: Citizen.first(offset: rand(Citizen.count))) }
 end
-
 voter_count = voters.size
-
 ideas = Idea.find(:all).to_a
 # first idea has 0 votes
 ideas.shift  
 # next ideas have only one for and against
 ideas.shift.vote(voters[rand(voter_count)], 0)
 ideas.shift.vote(voters[rand(voter_count)], 1)
-
 class RandomGaussian
   def initialize(mean = 0.0, sd = 1.0, rng = lambda { Kernel.rand })
     @mean, @sd, @rng = mean, sd, rng
@@ -280,8 +259,8 @@ class RandomGaussian
 
   def rand
     if (@compute_next_pair = !@compute_next_pair)
-      # Compute a pair of random values with normal distribution.
-      # See http://en.wikipedia.org/wiki/Box-Muller_transform
+# Compute a pair of random values with normal distribution.
+# See http://en.wikipedia.org/wiki/Box-Muller_transform
       theta = 2 * Math::PI * @rng.call
       scale = @sd * Math.sqrt(-2 * Math.log(1 - @rng.call))
       @g1 = @mean + scale * Math.sin(theta)
@@ -291,45 +270,39 @@ class RandomGaussian
     end
   end
 end
-
 # the rest should have all kinds of combinations
 secs_per_week = 60*60*24*7
 ideas.each do |idea|
-	rd = RandomGaussian.new(secs_per_week * (rand()*8.0+2.0), secs_per_week * (rand()*4.0+2.0))
-
-	# pick random count of random voters
-	vs = []
-	(0..rand(voter_count)).each do 
-		v = voters[rand(voter_count)]
-		while vs.include? v
-			v = voters[rand(voter_count)]
-		end
-		vs.push v
-	end
-	vs.each do |v|
+  rd = RandomGaussian.new(secs_per_week * (rand()*8.0+2.0), secs_per_week * (rand()*4.0+2.0))
+  # pick random count of random voters
+  vs = []
+  (0..rand(voter_count)).each do
+    v = voters[rand(voter_count)]
+    while vs.include? v
+      v = voters[rand(voter_count)]
+    end
+    vs.push v
+  end
+  vs.each do |v|
     idea.vote(v, rand(2))
-	end
+  end
 end
-
 # let's create some articles
-
 def read_till(f, breaker = /^---+/)
-	str = ""
-	while((l = f.gets) !~ breaker)
-		str.concat l
-	end
-	str
+  str = ""
+  while((l = f.gets) !~ breaker)
+    str.concat l
+  end
+  str
 end
-
 def field(f, name)
-	str = f.gets
-	if m = str.match(/^#{name}:/)
-		return m.post_match
-	else
-		raise "line #{str} does not match field name #{name}"
-	end
+  str = f.gets
+  if m = str.match(/^#{name}:/)
+    return m.post_match
+  else
+    raise "line #{str} does not match field name #{name}"
+  end
 end
-
 Dir["articles/*.md"].sort{|a,b| a <=> b}.each do |name|
   next unless File.file?(name)
   File.open(name) do |f|
@@ -343,7 +316,6 @@ Dir["articles/*.md"].sort{|a,b| a <=> b}.each do |name|
       ingress:      field(f, "ingress") && read_till(f),
       body:         field(f, "body") && read_till(f),
     }
-    
     Article.find_or_create_by_created_at(article)
   end
 end


### PR DESCRIPTION
After cleanup 'rake db:setup' works fine on Mac and Linux

Please do not use TABs and blank lines between ruby commands

Also each comment shold starts the newline without leading spaces

ruby tries to interpret everything when reading the seeds.rb
