### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ To keep track of the email sent you'll find the emails in the sent folder of the
 
 You can test the mail setup by clicking on link 'forget password'. It will send you instruction email when you will submit your email. Check your spam folder, if you are not getting emails.
 
-####NOTE:
+#### NOTE:
 Configure config.action_mailer.perform_deliveries = false in development.rb, if you want to STOP email deliveries in development mode.
 
 

--- a/articles/2012-02-29_15-43-00.md
+++ b/articles/2012-02-29_15-43-00.md
@@ -7,7 +7,7 @@ title: #Juristeille
 ingress:
 ---
 body:
-#Juristeille
+# Juristeille
 
 Tarvitsemme Avoimen ministeriö talkooporukkana juristeja. Lakimuutosideoiden joukkoistettu kehitteleminen ja vaikutusten arviointi on mahdollista maallikkovoimin tiettyyn pisteeseen saakka, mutta kaipaamme juristeja, jotka voivat osallistua säädöstekstin laadunvarmistukseen.
 

--- a/articles/2012-02-29_15-44-00.md
+++ b/articles/2012-02-29_15-44-00.md
@@ -7,7 +7,7 @@ title: #asiantuntijoille
 ingress:
 ---
 body:
-#Asiantuntijoille ja tutkijoille
+# Asiantuntijoille ja tutkijoille
 
 Avoin ministeriö pyrkii korostamaan asiantuntijuutta, tietoa ja tutkimusta. Lakiehdostuksiksi ryhdytään tyypillisesti valmistelemaan ideoita, jotka ovat saaneet asiantuntijoiden tukea. Voit ilmoittautua asiantuntijaksi tietylle idealle idean sivulla tai emailitse kanslia@avoinministerio.fi. 
 

--- a/articles/2012-02-29_15-45-00.md
+++ b/articles/2012-02-29_15-45-00.md
@@ -7,7 +7,7 @@ title: #Yhteystiedot
 ingress:
 ---
 body:
-#Yhteystiedot
+# Yhteystiedot
 
 Avoimen ministeriön projektivetäjänä ja PR-yhteyshenkilönä toimii Joonas Pekkanen (<http://www.linkedin.com/in/pekkanen>), joonas.pekkanen(ät)avoinministerio.fi ja 050-5846800.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
